### PR TITLE
fake a content interface for the default-provider

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,9 @@ assumes:
 plugs:
   foo-install-lxd:
     default-provider: lxd
+    interface: content
+    content: foo
+    target: $SNAP_DATA/foo
 
 parts:
   flutter-git:


### PR DESCRIPTION
It appears we need to fake a content interface for the default-provider to work