### PR TITLE
List supported image types for features

### DIFF
--- a/lib/launcher/feature_model.dart
+++ b/lib/launcher/feature_model.dart
@@ -14,7 +14,7 @@ class FeatureModel extends SafeChangeNotifier {
 
   bool hasFeature(LxdFeature feature) => _features.contains(feature);
   bool hasFeatures(Set<LxdFeature> features) => _features.containsAll(features);
-  final _features = Set.of(LxdFeature.values);
+  var _features = <LxdFeature>{};
   void setFeature(LxdFeature feature, bool value) {
     if (value) {
       _features.add(feature);
@@ -29,8 +29,13 @@ class FeatureModel extends SafeChangeNotifier {
   String? get user =>
       Platform.environment['USERNAME'] ?? Platform.environment['USER'];
 
-  Future<void> load() async {
-    // TODO: remember the last used features?
+  Future<void> init() async {
+    final features =
+        Set.of(LxdFeature.values.where((f) => f.isSupported(type)));
+    if (_features != features) {
+      _features = features;
+      notifyListeners();
+    }
   }
 
   LxdImage save() {

--- a/lib/launcher/feature_page.dart
+++ b/lib/launcher/feature_page.dart
@@ -28,7 +28,7 @@ class _FeaturePageState extends State<FeaturePage> {
   void initState() {
     super.initState();
     final model = context.read<FeatureModel>();
-    model.load();
+    WidgetsBinding.instance.addPostFrameCallback((_) => model.init());
   }
 
   @override
@@ -39,55 +39,62 @@ class _FeaturePageState extends State<FeaturePage> {
       content: RoundedContainer(
         child: ListView(
           children: [
-            CheckboxListTile(
-              title: const Text('User'),
-              subtitle: model.user != null
-                  ? Text(
-                      'Create a "${model.user!}" user account in the ${model.type.localize(context)}.')
-                  : null,
-              controlAffinity: ListTileControlAffinity.leading,
-              value: model.hasFeature(LxdFeature.user),
-              onChanged: model.user != null
-                  ? (value) => model.setFeature(LxdFeature.user, value!)
-                  : null,
-            ),
-            CheckboxListTile(
-              title: const Text('Home'),
-              subtitle: model.home != null
-                  ? Text(
-                      'Mount "${model.home!}" from the host into the ${model.type.localize(context)}.')
-                  : null,
-              controlAffinity: ListTileControlAffinity.leading,
-              value: model.hasFeature(LxdFeature.home),
-              onChanged: model.home != null && model.hasFeature(LxdFeature.user)
-                  ? (value) => model.setFeature(LxdFeature.home, value!)
-                  : null,
-            ),
-            CheckboxListTile(
-              title: const Text('Graphics'),
-              subtitle: const Text(
-                  'Make the host GPU available and forward display connections.'),
-              controlAffinity: ListTileControlAffinity.leading,
-              value: model.hasFeature(LxdFeature.graphics),
-              onChanged: (value) =>
-                  model.setFeature(LxdFeature.graphics, value!),
-            ),
-            CheckboxListTile(
-              title: const Text('Audio'),
-              subtitle: const Text(
-                  'Make the host sound card available and forward audio connections.'),
-              controlAffinity: ListTileControlAffinity.leading,
-              value: model.hasFeature(LxdFeature.audio),
-              onChanged: (value) => model.setFeature(LxdFeature.audio, value!),
-            ),
-            CheckboxListTile(
-              title: const Text('LXD'),
-              subtitle: Text(
-                  'Make the LXD server on the host accessible from the ${model.type.localize(context)}.'),
-              controlAffinity: ListTileControlAffinity.leading,
-              value: model.hasFeature(LxdFeature.lxd),
-              onChanged: (value) => model.setFeature(LxdFeature.lxd, value!),
-            ),
+            if (LxdFeature.user.isSupported(model.type))
+              CheckboxListTile(
+                title: const Text('User'),
+                subtitle: model.user != null
+                    ? Text(
+                        'Create a "${model.user!}" user account in the ${model.type.localize(context)}.')
+                    : null,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: model.hasFeature(LxdFeature.user),
+                onChanged: model.user != null
+                    ? (value) => model.setFeature(LxdFeature.user, value!)
+                    : null,
+              ),
+            if (LxdFeature.home.isSupported(model.type))
+              CheckboxListTile(
+                title: const Text('Home'),
+                subtitle: model.home != null
+                    ? Text(
+                        'Mount "${model.home!}" from the host into the ${model.type.localize(context)}.')
+                    : null,
+                controlAffinity: ListTileControlAffinity.leading,
+                value: model.hasFeature(LxdFeature.home),
+                onChanged:
+                    model.home != null && model.hasFeature(LxdFeature.user)
+                        ? (value) => model.setFeature(LxdFeature.home, value!)
+                        : null,
+              ),
+            if (LxdFeature.graphics.isSupported(model.type))
+              CheckboxListTile(
+                title: const Text('Graphics'),
+                subtitle: const Text(
+                    'Make the host GPU available and forward display connections.'),
+                controlAffinity: ListTileControlAffinity.leading,
+                value: model.hasFeature(LxdFeature.graphics),
+                onChanged: (value) =>
+                    model.setFeature(LxdFeature.graphics, value!),
+              ),
+            if (LxdFeature.audio.isSupported(model.type))
+              CheckboxListTile(
+                title: const Text('Audio'),
+                subtitle: const Text(
+                    'Make the host sound card available and forward audio connections.'),
+                controlAffinity: ListTileControlAffinity.leading,
+                value: model.hasFeature(LxdFeature.audio),
+                onChanged: (value) =>
+                    model.setFeature(LxdFeature.audio, value!),
+              ),
+            if (LxdFeature.lxd.isSupported(model.type))
+              CheckboxListTile(
+                title: const Text('LXD'),
+                subtitle: Text(
+                    'Make the LXD server on the host accessible from the ${model.type.localize(context)}.'),
+                controlAffinity: ListTileControlAffinity.leading,
+                value: model.hasFeature(LxdFeature.lxd),
+                onChanged: (value) => model.setFeature(LxdFeature.lxd, value!),
+              ),
           ],
         ),
       ),

--- a/packages/lxd_service/lib/src/features.dart
+++ b/packages/lxd_service/lib/src/features.dart
@@ -1,24 +1,29 @@
+import 'package:lxd/lxd.dart';
+
 import 'features/audio.dart';
-import 'features/feature.dart';
 import 'features/graphics.dart';
 import 'features/home.dart';
+import 'features/provider.dart';
 import 'features/server.dart';
 import 'features/user.dart';
 
 export 'features/context.dart';
-export 'features/feature.dart';
+export 'features/provider.dart';
 
 enum LxdFeature {
-  user(LxdUserFeature.new),
-  home(LxdHomeFeature.new),
-  graphics(LxdGraphicsFeature.new),
-  audio(LxdAudioFeature.new),
-  lxd(LxdServerFeature.new);
+  user(const LxdUserFeature()),
+  home(const LxdHomeFeature()),
+  graphics(const LxdGraphicsFeature()),
+  audio(const LxdAudioFeature()),
+  lxd(const LxdServerFeature());
 
-  const LxdFeature(this._factory);
-  final LxdImageFeature Function() _factory;
+  const LxdFeature(this._provider);
+  final LxdFeatureProvider _provider;
 
-  static LxdImageFeature create(LxdFeature feature) {
-    return feature._factory();
+  bool isSupported(LxdImageType type) =>
+      _provider.supportedTypes.contains(type);
+
+  static LxdFeatureProvider get(LxdFeature feature) {
+    return feature._provider;
   }
 }

--- a/packages/lxd_service/lib/src/features/audio.dart
+++ b/packages/lxd_service/lib/src/features/audio.dart
@@ -1,10 +1,16 @@
+import 'package:lxd/lxd.dart';
 import 'package:stdlibc/stdlibc.dart';
 
 import 'context.dart';
-import 'feature.dart';
+import 'provider.dart';
 
-class LxdAudioFeature extends LxdImageFeature {
+class LxdAudioFeature extends LxdFeatureProvider {
   const LxdAudioFeature();
+
+  // only containers can proxy unix domain sockets
+  // https://linuxcontainers.org/lxd/docs/master/instances/#type-proxy
+  @override
+  Set<LxdImageType> get supportedTypes => const {LxdImageType.container};
 
   @override
   List<String> getDirectories(LxdFeatureContext context) {

--- a/packages/lxd_service/lib/src/features/graphics.dart
+++ b/packages/lxd_service/lib/src/features/graphics.dart
@@ -1,10 +1,16 @@
+import 'package:lxd/lxd.dart';
 import 'package:stdlibc/stdlibc.dart';
 
 import 'context.dart';
-import 'feature.dart';
+import 'provider.dart';
 
-class LxdGraphicsFeature extends LxdImageFeature {
+class LxdGraphicsFeature extends LxdFeatureProvider {
   const LxdGraphicsFeature();
+
+  // only containers can proxy unix domain sockets
+  // https://linuxcontainers.org/lxd/docs/master/instances/#type-proxy
+  @override
+  Set<LxdImageType> get supportedTypes => const {LxdImageType.container};
 
   @override
   List<String> getDirectories(LxdFeatureContext context) =>

--- a/packages/lxd_service/lib/src/features/home.dart
+++ b/packages/lxd_service/lib/src/features/home.dart
@@ -1,7 +1,7 @@
 import 'context.dart';
-import 'feature.dart';
+import 'provider.dart';
 
-class LxdHomeFeature extends LxdImageFeature {
+class LxdHomeFeature extends LxdFeatureProvider {
   const LxdHomeFeature();
 
   @override

--- a/packages/lxd_service/lib/src/features/provider.dart
+++ b/packages/lxd_service/lib/src/features/provider.dart
@@ -2,8 +2,10 @@ import 'package:lxd/lxd.dart';
 
 import 'context.dart';
 
-abstract class LxdImageFeature {
-  const LxdImageFeature();
+abstract class LxdFeatureProvider {
+  const LxdFeatureProvider();
+
+  Set<LxdImageType> get supportedTypes => Set.of(LxdImageType.values);
 
   List<String> getDirectories(LxdFeatureContext context) => const [];
   Map<String, String> getFiles(LxdFeatureContext context) => const {};

--- a/packages/lxd_service/lib/src/features/server.dart
+++ b/packages/lxd_service/lib/src/features/server.dart
@@ -1,8 +1,15 @@
-import 'context.dart';
-import 'feature.dart';
+import 'package:lxd/lxd.dart';
 
-class LxdServerFeature extends LxdImageFeature {
+import 'context.dart';
+import 'provider.dart';
+
+class LxdServerFeature extends LxdFeatureProvider {
   const LxdServerFeature();
+
+  // only containers can proxy unix domain sockets
+  // https://linuxcontainers.org/lxd/docs/master/instances/#type-proxy
+  @override
+  Set<LxdImageType> get supportedTypes => const {LxdImageType.container};
 
   @override
   List<String> getDirectories(LxdFeatureContext context) {

--- a/packages/lxd_service/lib/src/features/user.dart
+++ b/packages/lxd_service/lib/src/features/user.dart
@@ -3,9 +3,9 @@ import 'package:lxd/lxd.dart';
 import 'package:stdlibc/stdlibc.dart';
 
 import 'context.dart';
-import 'feature.dart';
+import 'provider.dart';
 
-class LxdUserFeature extends LxdImageFeature {
+class LxdUserFeature extends LxdFeatureProvider {
   const LxdUserFeature();
 
   @override

--- a/packages/lxd_service/lib/src/service.dart
+++ b/packages/lxd_service/lib/src/service.dart
@@ -117,17 +117,17 @@ class _LxdService implements LxdService {
     final start = await _client.startInstance(name);
     await _client.waitOperation(start.id);
 
-    final featureNames = image.properties['user.features']?.split(',').toSet();
-    final features = LxdFeature.values
-        .where((feature) => featureNames?.contains(feature.name) == true)
-        .map(LxdFeature.create);
+    final features = image.properties['user.features']?.split(',').toSet();
+    final providers = LxdFeature.values
+        .where((feature) => features?.contains(feature.name) == true)
+        .map(LxdFeature.get);
 
     final init = LxdFeatureContext(
       image: image,
       username: image.properties['user.username']!,
     );
 
-    for (final feature in features) {
+    for (final feature in providers) {
       final instance = await _client.getInstance(name);
       await feature.init(client, instance, init);
     }
@@ -140,7 +140,7 @@ class _LxdService implements LxdService {
       gid: await client.gid(name, init.username),
     );
 
-    for (final feature in features) {
+    for (final feature in providers) {
       final dirs = feature.getDirectories(context);
       for (final dir in dirs) {
         await client.mkdir(name, dir);
@@ -160,11 +160,11 @@ class _LxdService implements LxdService {
       instance.copyWith(
         config: {
           ...instance.config,
-          for (final feature in features) ...feature.getConfig(context),
+          for (final feature in providers) ...feature.getConfig(context),
         },
         devices: {
           ...instance.devices,
-          for (final feature in features) ...feature.getDevices(context),
+          for (final feature in providers) ...feature.getDevices(context),
         },
       ),
     );


### PR DESCRIPTION
For example, only containers can proxy UNIX domain sockets which means
we cannot proxy audio, graphics, or lxd sockets for VMs:

> Invalid devices: Device validation failed for "pulse": Only NAT mode is supported for proxies on VM instances
> Invalid devices: Device validation failed for "x11": Only NAT mode is supported for proxies on VM instances
> Invalid devices: Device validation failed for "lxd": Only NAT mode is supported for proxies on VM instances

https://linuxcontainers.org/lxd/docs/master/instances/#type-proxy