### PR TITLE
Add a mechanism for waiting the VM agent

### DIFF
--- a/packages/lxd_service/lib/src/service.dart
+++ b/packages/lxd_service/lib/src/service.dart
@@ -29,6 +29,7 @@ abstract class LxdService {
   Future<LxdOperation> stopInstance(String name, {bool force = false});
   Future<LxdOperation> deleteInstance(String name);
   Stream<LxdOperation> watchInstance(String instance);
+  Future<void> waitVmAgent(String name, {Duration? timeout});
 
   Future<LxdOperation> getOperation(String id);
   Stream<LxdOperation> watchOperation(String id);
@@ -187,6 +188,10 @@ class _LxdService implements LxdService {
         .where((event) => event.isOperation)
         .map((event) => LxdOperation.fromJson(event.metadata!))
         .where((op) => op.instances?.contains(instance) == true);
+  }
+
+  Future<void> waitVmAgent(String name, {Duration? timeout}) {
+    return _client.waitVmAgent(name, timeout: timeout);
   }
 
   @override


### PR DESCRIPTION
This can be used as a workaround to get past the problem that after launching a VM, despite that LXD reports that it's "Running", one cannot execute commands until the VM agent is up and running:
```
$ lxc launch ubuntu:22.04 foo --vm
Creating foo
Starting foo                              
$ lxc exec foo -- pwd
Error: LXD VM agent isn't currently running
$ lxc exec foo -- pwd
Error: LXD VM agent isn't currently running
$ lxc exec foo -- pwd
/root
```

The workaround was proposed on the #lxd channel:
> @jpnurmi if you call `lxc info <instance>` or `/1.0/instances/<instance>?recursion=1` if the `processes` is > -1 then the agent is running.