### PR TITLE
Revert "Pin Flutter version to 3.0.5 (#64)"

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.0.5'
-          channel: 'stable'
       - run: flutter pub global activate melos
       - run: melos bootstrap
       - run: melos run analyze
@@ -25,9 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.0.5'
-          channel: 'stable'
       - run: flutter pub global activate melos
       - run: melos bootstrap
       - run: melos run format
@@ -37,9 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.0.5'
-          channel: 'stable'
       - run: flutter pub global activate melos
       - run: melos bootstrap
       - run: melos exec --no-private -- \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.5'
-        channel: 'stable'
     - run: flutter pub global activate melos
     - run: sudo apt update
     - run: sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb
@@ -25,7 +22,6 @@ jobs:
     - run: melos build
 
   snap:
-    if: ${{false}}
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -14,9 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.5'
-        channel: 'stable'
     - run: flutter pub global activate melos
     - run: melos bootstrap
     - run: flutter pub get # Bad state: Unable to generate package graph
@@ -29,9 +26,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.5'
-        channel: 'stable'
     - run: flutter pub global activate melos
     - run: melos bootstrap
     - run: melos run gen-l10n
@@ -43,9 +37,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.5'
-        channel: 'stable'
     - run: flutter pub global activate melos
     - run: melos bootstrap
     - run: flutter pub get # Bad state: Unable to generate package graph

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.5'
-        channel: 'stable'
     - run: flutter pub global activate melos
     - run: sudo apt update
     - run: sudo apt install -y lcov
@@ -32,9 +29,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.5'
-        channel: 'stable'
     - run: flutter pub global activate melos
     - run: melos bootstrap
     - run: melos run test
@@ -44,9 +38,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '3.0.5'
-        channel: 'stable'
     - run: flutter pub global activate melos
     - run: sudo apt update
     - run: sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip xvfb

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ assumes:
 parts:
   flutter-git:
     source: https://github.com/flutter/flutter.git
-    source-tag: 3.0.5
+    source-branch: stable
     plugin: nil
     override-build: |
       mkdir -p $CRAFT_PART_INSTALL/usr/bin


### PR DESCRIPTION
This reverts commit a845bcb19f6568c5f45f5f299bc2ff42eb4da376 because yaru.dart 0.4 depends on Flutter 3.3 and the [raster cache rendering issue](https://github.com/jpnurmi/flutter_raster_cache_bug) has been already fixed in Flutter 3.3.2.