### PR TITLE
CI: nightly snap build

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,10 +1,8 @@
 name: Snap
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  schedule:
+  - cron:  '45 6 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
arm64 builds (#90) are slow - we don't need them for every PR.