### PR TITLE
Revert "Pin analyzer"

### DIFF
--- a/packages/command_store/pubspec.yaml
+++ b/packages/command_store/pubspec.yaml
@@ -20,7 +20,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: 5.3.2
-
-dependency_overrides:
-  # https://github.com/canonical/workshops/pull/158
-  analyzer: 5.1.0

--- a/packages/os_logo/pubspec.yaml
+++ b/packages/os_logo/pubspec.yaml
@@ -21,7 +21,3 @@ dev_dependencies:
 flutter:
   assets:
     - assets/
-
-dependency_overrides:
-  # https://github.com/canonical/workshops/pull/158
-  analyzer: 5.1.0


### PR DESCRIPTION
Reverts canonical/workshops#158 which is no longer needed.

```
Failed to build build_runner:build_runner:
../../../../../.pub-cache/hosted/pub.dartlang.org/build_resolvers-2.1.0/lib/src/resolver.dart:266:32: Error: The getter 'parts' isn't defined for the class 'LibraryElement'.
 - 'LibraryElement' is from 'package:analyzer/dart/element/element.dart' ('../../../../../.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/dart/element/element.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'parts'.
    for (final part in element.parts) {
                               ^^^^^
../../../../../.pub-cache/hosted/pub.dartlang.org/build_resolvers-2.1.0/lib/src/resolver.dart:310:19: Error: The getter 'sdkLibraryUris' isn't defined for the class 'AnalysisDriverForPackageBuild'.
 - 'AnalysisDriverForPackageBuild' is from 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart' ('../../../../../.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/src/clients/build_resolvers/build_resolvers.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'sdkLibraryUris'.
          _driver.sdkLibraryUris.where((e) => !e.path.startsWith('_'));
                  ^^^^^^^^^^^^^^
../../../../../.pub-cache/hosted/pub.dartlang.org/build_resolvers-2.1.0/lib/src/resolver.dart:469:13: Error: Method not found: 'buildSdkSummary'.
      await buildSdkSummary(
            ^^^^^^^^^^^^^^^


pub finished with exit code 1
```