### PR TITLE
settings_store: remove DBusValue from the API

### DIFF
--- a/lib/terminal/terminal_settings.dart
+++ b/lib/terminal/terminal_settings.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:dbus/dbus.dart';
 import 'package:settings_store/settings_store.dart';
 import 'package:terminal_view/terminal_view.dart';
 
@@ -10,14 +9,13 @@ const _kFontSize = 'terminal-font-size';
 const _kFontFamily = 'terminal-font-family';
 
 extension TerminalSettings on SettingsStore {
-  double? get fontSize => get(_kFontSize)?.asDouble();
+  double? get fontSize => get(_kFontSize);
   set fontSize(double? value) =>
-      value != null ? set(_kFontSize, DBusDouble(value)) : unset(_kFontSize);
+      value != null ? set(_kFontSize, value) : unset(_kFontSize);
 
-  String? get fontFamily => get(_kFontFamily)?.asString();
-  set fontFamily(String? value) => value != null
-      ? set(_kFontFamily, DBusString(value))
-      : unset(_kFontFamily);
+  String? get fontFamily => get(_kFontFamily);
+  set fontFamily(String? value) =>
+      value != null ? set(_kFontFamily, value) : unset(_kFontFamily);
 
   TerminalThemeData getTheme(String? os) {
     return defaultTheme(os).copyWith(

--- a/packages/command_store/lib/src/shortcut_store.dart
+++ b/packages/command_store/lib/src/shortcut_store.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:accel_key/accel_key.dart';
 import 'package:collection/collection.dart';
-import 'package:dbus/dbus.dart';
 import 'package:flutter/widgets.dart';
 import 'package:settings_store/settings_store.dart';
 
@@ -13,7 +12,7 @@ class ShortcutStore extends SettingsStore {
   ShortcutStore.of(super.gsettings);
 
   List<LogicalKeySet>? getShortcuts(String id) {
-    return get(id)?.toLogicalKeySets();
+    return get<List<String>>(id)?.toLogicalKeySets();
   }
 
   Future<void> addShortcut(String id, LogicalKeySet shortcut) {
@@ -29,23 +28,20 @@ class ShortcutStore extends SettingsStore {
   }
 
   Future<void> setShortcuts(String id, List<LogicalKeySet> shortcuts) {
-    return set(id, shortcuts.toDbusArray());
+    return set(id, shortcuts.toStringList());
   }
 
   Future<void> removeShortcuts(String id) => unset(id);
 }
 
-extension _DBusValueX on DBusValue {
+extension _StringListX on List<String> {
   List<LogicalKeySet> toLogicalKeySets() {
-    return asArray()
-        .map((k) => parseAccelKey(k.asString()))
-        .whereNotNull()
-        .toList();
+    return map(parseAccelKey).whereNotNull().toList();
   }
 }
 
 extension _LogicalKeySetListX on List<LogicalKeySet> {
-  DBusArray toDbusArray() {
-    return DBusArray.string(map(formatAccelKey).whereNotNull().toList());
+  List<String> toStringList() {
+    return map(formatAccelKey).whereNotNull().toList();
   }
 }

--- a/packages/command_store/pubspec.yaml
+++ b/packages/command_store/pubspec.yaml
@@ -9,7 +9,6 @@ dependencies:
   accel_key:
     path: ../accel_key
   collection: ^1.16.0
-  dbus: ^0.7.8
   flutter:
     sdk: flutter
   gsettings: ^0.2.5

--- a/packages/command_store/test/command_store_test.mocks.dart
+++ b/packages/command_store/test/command_store_test.mocks.dart
@@ -4,10 +4,9 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
-import 'dart:ui' as _i6;
+import 'dart:ui' as _i5;
 
 import 'package:command_store/src/shortcut_store.dart' as _i2;
-import 'package:dbus/dbus.dart' as _i5;
 import 'package:flutter/widgets.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
@@ -113,14 +112,14 @@ class MockShortcutStore extends _i1.Mock implements _i2.ShortcutStore {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  _i5.DBusValue? get(String? key) => (super.noSuchMethod(Invocation.method(
+  T? get<T>(String? key) => (super.noSuchMethod(Invocation.method(
         #get,
         [key],
-      )) as _i5.DBusValue?);
+      )) as T?);
   @override
-  _i4.Future<void> set(
+  _i4.Future<void> set<T>(
     String? key,
-    _i5.DBusValue? value,
+    T? value,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -152,7 +151,7 @@ class MockShortcutStore extends _i1.Mock implements _i2.ShortcutStore {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -160,7 +159,7 @@ class MockShortcutStore extends _i1.Mock implements _i2.ShortcutStore {
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/packages/settings_store/lib/settings_store.dart
+++ b/packages/settings_store/lib/settings_store.dart
@@ -36,11 +36,52 @@ class SettingsStore extends ChangeNotifier {
   }
 
   Iterable<String> get keys => _values.keys;
-  DBusValue? get(String key) => _values[key];
-  Future<void> set(String key, DBusValue value) => _gsettings.set(key, value);
+
+  T? get<T>(String key) => _fromDbusValue<T>(_values[key]) as T?;
+
+  Future<void> set<T>(String key, T value) {
+    return _gsettings.set(key, _toDbusValue<T>(value));
+  }
+
   Future<void> unset(String key) => _gsettings.unset(key);
 
-  Future<DBusValue> _getValue(String key) => _gsettings.get(key);
+  Future<DBusValue> _getValue<T>(String key) {
+    return _gsettings.get(key).then((v) => v);
+  }
+
+  dynamic _fromDbusValue<T>(DBusValue? value) {
+    switch (T) {
+      case bool:
+        return value?.asBoolean();
+      case int:
+        return value?.asInt32();
+      case double:
+        return value?.asDouble();
+      case String:
+        return value?.asString();
+      case List<String>:
+        return value?.asStringArray().toList();
+      default:
+        return value?.toNative();
+    }
+  }
+
+  DBusValue _toDbusValue<T>(T value) {
+    switch (T) {
+      case bool:
+        return DBusBoolean(value as bool);
+      case int:
+        return DBusInt32(value as int);
+      case double:
+        return DBusDouble(value as double);
+      case String:
+        return DBusString(value as String);
+      case List<String>:
+        return DBusArray.string(value as List<String>);
+      default:
+        throw UnsupportedError('$T');
+    }
+  }
 
   @override
   Future<void> dispose() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   context_menu:
     path: packages/context_menu
   data_size: ^0.2.0
-  dbus: ^0.7.8
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
Makes it easier to have different settings backends e.g. for WSL or core desktop.