### PR TITLE
Add <Control><Shift>plus as an alternative default zoom-in shortcut

### DIFF
--- a/assets/shortcuts.json
+++ b/assets/shortcuts.json
@@ -22,7 +22,10 @@
   "terminal-focus-down": "<Alt>Down",
   "terminal-focus-left": "<Alt>Left",
   "terminal-focus-right": "<Alt>Right",
-  "terminal-zoom-in": "<Control>plus",
+  "terminal-zoom-in": [
+    "<Control>plus",
+    "<Control><Shift>plus"
+  ],
   "terminal-zoom-out": "<Control>minus",
   "terminal-zoom-reset": "<Control>0"
 }


### PR DESCRIPTION
The editor only shows the first shortcut so it's kind of a hidden extra shortcut to support the US keyboard layout. :)