### PR TITLE
Tweak title bars

### DIFF
--- a/lib/launcher/launcher_page.dart
+++ b/lib/launcher/launcher_page.dart
@@ -50,19 +50,20 @@ class LauncherPage extends StatelessWidget {
                   : null,
               trailing: Hero(
                 tag: '$this',
-                child: YaruCloseButton(
-                  onPressed: context.read<LauncherModel>().cancel,
+                child: YaruWindowControl(
+                  type: YaruWindowControlType.close,
+                  onTap: context.read<LauncherModel>().cancel,
                 ),
               ),
             ),
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24),
+                padding: const EdgeInsets.all(24),
                 child: content,
               ),
             ),
             Padding(
-              padding: const EdgeInsets.all(24),
+              padding: const EdgeInsets.only(left: 24, bottom: 24, right: 24),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: actions.separated(const SizedBox(width: 8)).toList(),

--- a/lib/preferences/preferences_dialog.dart
+++ b/lib/preferences/preferences_dialog.dart
@@ -45,7 +45,7 @@ class PreferencesDialog extends StatelessWidget {
               ),
               Expanded(
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  padding: const EdgeInsets.all(24),
                   child: RoundedContainer(
                     child: YaruMasterDetailPage(
                       length: 1,
@@ -61,7 +61,7 @@ class PreferencesDialog extends StatelessWidget {
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.all(24),
+                padding: const EdgeInsets.only(left: 24, bottom: 24, right: 24),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [

--- a/packages/title_bar/lib/src/dialog_title_bar.dart
+++ b/packages/title_bar/lib/src/dialog_title_bar.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import 'title_bar_theme.dart';
+
 class DialogTitleBar extends StatelessWidget {
   const DialogTitleBar({super.key, this.title, this.leading, this.trailing});
 
@@ -11,25 +13,39 @@ class DialogTitleBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return GestureDetector(
       onPanStart: (_) => windowManager.startDragging(),
-      child: Theme(
-        data: Theme.of(context).copyWith(
-          appBarTheme: AppBarTheme(
-            shape: const Border(),
-            titleSpacing: leading != null ? 8 : 24,
-          ),
+      onSecondaryTap: windowManager.popUpWindowMenu,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.titleBarColor(),
         ),
-        child: YaruTitleBar(
-          title: title,
-          centerTitle: false,
-          leading: leading != null
-              ? Padding(
-                  padding: const EdgeInsetsDirectional.only(start: 16),
-                  child: Center(child: leading!),
-                )
-              : null,
-          trailing: trailing,
+        child: Theme(
+          data: theme.copyWith(
+            appBarTheme: theme.appBarTheme.copyWith(
+              shape: const Border(),
+              titleSpacing: leading != null ? 8 : 24,
+            ),
+          ),
+          child: YaruTitleBar(
+            title: title,
+            centerTitle: false,
+            leading: leading != null
+                ? Padding(
+                    padding: const EdgeInsetsDirectional.only(start: 16),
+                    child: Center(child: leading!),
+                  )
+                : null,
+            trailing: Padding(
+              padding: const EdgeInsets.all(8),
+              child: trailing ??
+                  YaruWindowControl(
+                    type: YaruWindowControlType.close,
+                    onTap: () => Navigator.maybePop(context),
+                  ),
+            ),
+          ),
         ),
       ),
     );

--- a/packages/title_bar/lib/src/title_bar_theme.dart
+++ b/packages/title_bar/lib/src/title_bar_theme.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+extension ThemeDataX on ThemeData {
+  Color titleBarColor({bool active = false}) {
+    return backgroundColor.darken(active ? 0.04 : 0.01);
+  }
+
+  Border titleBarBorder() {
+    return Border(
+      bottom: BorderSide(color: backgroundColor.darken(0.1)),
+    );
+  }
+}
+
+extension _ColorX on Color {
+  Color darken(double amount) {
+    final hsl = HSLColor.fromColor(this);
+    return hsl
+        .withLightness((hsl.lightness - amount).clamp(0.0, 1.0))
+        .toColor();
+  }
+}

--- a/packages/title_bar/lib/src/window_title_bar.dart
+++ b/packages/title_bar/lib/src/window_title_bar.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import 'title_bar_theme.dart';
 
 const _kTitleBarHeight = 46.0;
 
@@ -99,12 +102,10 @@ class _TitleBarLayoutState extends State<_TitleBarLayout> with WindowListener {
       },
       onSecondaryTap: windowManager.popUpWindowMenu,
       child: Theme(
-        data: Theme.of(context).copyWith(
-          appBarTheme: Theme.of(context).appBarTheme.copyWith(
-                shape: Border(
-                  bottom: BorderSide(color: theme.backgroundColor.darken(0.1)),
-                ),
-              ),
+        data: theme.copyWith(
+          appBarTheme: theme.appBarTheme.copyWith(
+            shape: theme.titleBarBorder(),
+          ),
         ),
         child: AppBar(
           leading: widget.icon != null
@@ -117,66 +118,19 @@ class _TitleBarLayoutState extends State<_TitleBarLayout> with WindowListener {
           centerTitle: widget.centerTitle ?? true,
           titleSpacing: widget.titleSpacing,
           toolbarHeight: _kTitleBarHeight,
-          backgroundColor:
-              theme.backgroundColor.darken(_isActive ? 0.04 : 0.01),
+          backgroundColor: theme.titleBarColor(active: _isActive),
           actions: [
             if (_isClosable)
-              _TitleBarButton(
-                icon: const Icon(YaruIcons.window_close),
-                states: {if (_isActive) MaterialState.focused},
-                onPressed: windowManager.close,
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: YaruWindowControl(
+                  type: YaruWindowControlType.close,
+                  onTap: windowManager.close,
+                ),
               ),
           ],
         ),
       ),
     );
-  }
-}
-
-class _TitleBarButton extends StatelessWidget {
-  const _TitleBarButton({
-    required this.icon,
-    required this.states,
-    required this.onPressed,
-  });
-
-  final Widget icon;
-  final Set<MaterialState> states;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsetsDirectional.all(8),
-      child: Center(
-        child: IconButton(
-          icon: icon,
-          iconSize: 16,
-          padding: EdgeInsets.zero,
-          visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-          onPressed: onPressed,
-          style: ButtonStyle(
-            backgroundColor: MaterialStateProperty.resolveWith((_) {
-              if (states.contains(MaterialState.focused)) {
-                return Theme.of(context)
-                    .colorScheme
-                    .onSurface
-                    .withOpacity(0.08);
-              }
-              return null;
-            }),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-extension _ColorX on Color {
-  Color darken(double amount) {
-    final hsl = HSLColor.fromColor(this);
-    return hsl
-        .withLightness((hsl.lightness - amount).clamp(0.0, 1.0))
-        .toColor();
   }
 }


### PR DESCRIPTION
- Make dialog title bars look more like window title bars to give a visual clue that the window is movable.
- Use YaruWindowControl
- Adjust dialog paddings to leave a gap between the title bar and the content frame

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/203564000-d22a06f4-17cd-42e7-ba72-a945a4679231.png) | ![image](https://user-images.githubusercontent.com/140617/203563473-9198a700-71a7-4f1b-b786-e02512688a0b.png) |
| ![image](https://user-images.githubusercontent.com/140617/203564039-695f1694-8f4d-47dd-800c-b86a9d5a754f.png) | ![image](https://user-images.githubusercontent.com/140617/203563882-d7821d6f-9ac0-4c7a-bcc5-de0592eda79a.png) |
| ![image](https://user-images.githubusercontent.com/140617/203564070-3d571dc6-760e-43d2-a21e-89b29fba0843.png) | ![image](https://user-images.githubusercontent.com/140617/203563910-85565faf-2789-4c23-b7fb-fb0c7686461f.png) |
| ![image](https://user-images.githubusercontent.com/140617/203564101-b028dee7-5c0c-4cff-ac0d-6779e8f1037c.png) | ![image](https://user-images.githubusercontent.com/140617/203563928-c7b50409-c328-43d4-8dee-d52767af77e0.png) |
