### PR TITLE
Upgrade lxd.dart to a version with project support

### DIFF
--- a/packages/lxd_service/lib/src/features/user.dart
+++ b/packages/lxd_service/lib/src/features/user.dart
@@ -47,7 +47,7 @@ gid ${getgid()} $gid
 
     // sudo vs. wheel
     final group =
-        await client.pullFile(instance.name, path: '/etc/group').then((data) {
+        await client.pullFile(instance.id, path: '/etc/group').then((data) {
       return data
           .split('\n')
           .firstWhereOrNull(
@@ -58,7 +58,7 @@ gid ${getgid()} $gid
 
     // useradd
     return client.execInstance(
-      instance.name,
+      instance.id,
       command: [
         'useradd',
         '--create-home',

--- a/packages/lxd_service/pubspec.yaml
+++ b/packages/lxd_service/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: 9799464c4488f52203407169baca963f88f0e349
+      ref: 48f586befd7a4229ccf2b25b7b6e7590214db03d
   lxd_test:
     path: ../lxd_test
   lxd_x:

--- a/packages/lxd_service/test/lxd_service_test.dart
+++ b/packages/lxd_service/test/lxd_service_test.dart
@@ -11,6 +11,10 @@ import 'package:test/test.dart';
 
 import 'lxd_service_test.mocks.dart';
 
+const fooId = LxdInstanceId('foo');
+const barId = LxdInstanceId('bar');
+const bazId = LxdInstanceId('baz');
+
 @GenerateMocks([LxdClient, WebSocket])
 void main() {
   test('init', () async {
@@ -18,7 +22,7 @@ void main() {
     final events = StreamController<LxdEvent>();
     when(client.getEvents(types: {LxdEventType.operation}))
         .thenAnswer((_) => events.stream);
-    when(client.getInstances()).thenAnswer((_) async => ['foo']);
+    when(client.getInstances()).thenAnswer((_) async => [fooId]);
     when(client.getOperations()).thenAnswer((_) async => {
           'running': ['op']
         });
@@ -73,71 +77,71 @@ void main() {
   test('start instance', () async {
     final op = testOperation();
     final client = MockLxdClient();
-    when(client.startInstance('foo', force: anyNamed('force')))
+    when(client.startInstance(fooId, force: anyNamed('force')))
         .thenAnswer((_) async => op);
 
     final service = LxdService(client);
 
     await service.startInstance('foo');
-    verify(client.startInstance('foo', force: false)).called(1);
+    verify(client.startInstance(fooId, force: false)).called(1);
 
     await service.startInstance('foo', force: false);
-    verify(client.startInstance('foo', force: false)).called(1);
+    verify(client.startInstance(fooId, force: false)).called(1);
 
     await service.startInstance('foo', force: true);
-    verify(client.startInstance('foo', force: true)).called(1);
+    verify(client.startInstance(fooId, force: true)).called(1);
   });
 
   test('restart instance', () async {
     final op = testOperation();
     final client = MockLxdClient();
-    when(client.restartInstance('foo',
+    when(client.restartInstance(fooId,
             force: anyNamed('force'), timeout: anyNamed('timeout')))
         .thenAnswer((_) async => op);
 
     final service = LxdService(client);
 
     await service.restartInstance('foo');
-    verify(client.restartInstance('foo', force: false, timeout: null))
+    verify(client.restartInstance(fooId, force: false, timeout: null))
         .called(1);
 
     await service.restartInstance('foo', force: true);
-    verify(client.restartInstance('foo', force: true, timeout: null)).called(1);
+    verify(client.restartInstance(fooId, force: true, timeout: null)).called(1);
 
     await service.restartInstance('foo', force: false, timeout: Duration.zero);
-    verify(client.restartInstance('foo', force: false, timeout: Duration.zero))
+    verify(client.restartInstance(fooId, force: false, timeout: Duration.zero))
         .called(1);
   });
 
   test('stop instance', () async {
     final op = testOperation();
     final client = MockLxdClient();
-    when(client.stopInstance('foo',
+    when(client.stopInstance(fooId,
             force: anyNamed('force'), timeout: anyNamed('timeout')))
         .thenAnswer((_) async => op);
 
     final service = LxdService(client);
 
     await service.stopInstance('foo');
-    verify(client.stopInstance('foo', force: false, timeout: null)).called(1);
+    verify(client.stopInstance(fooId, force: false, timeout: null)).called(1);
 
     await service.stopInstance('foo', force: true);
-    verify(client.stopInstance('foo', force: true, timeout: null)).called(1);
+    verify(client.stopInstance(fooId, force: true, timeout: null)).called(1);
 
     await service.stopInstance('foo', force: false, timeout: Duration.zero);
-    verify(client.stopInstance('foo', force: false, timeout: Duration.zero))
+    verify(client.stopInstance(fooId, force: false, timeout: Duration.zero))
         .called(1);
   });
 
   test('delete instance', () async {
     final op = testOperation();
     final client = MockLxdClient();
-    when(client.deleteInstance('foo')).thenAnswer((_) async => op);
+    when(client.deleteInstance(fooId)).thenAnswer((_) async => op);
 
     final service = LxdService(client);
 
     await service.deleteInstance('foo');
-    verify(client.deleteInstance('foo')).called(1);
+    verify(client.deleteInstance(fooId)).called(1);
   });
 
   test('instance added', () async {
@@ -145,13 +149,13 @@ void main() {
     final events = StreamController<LxdEvent>();
     when(client.getEvents(types: {LxdEventType.operation}))
         .thenAnswer((_) => events.stream);
-    when(client.getInstances()).thenAnswer((_) async => ['foo']);
+    when(client.getInstances()).thenAnswer((_) async => [fooId]);
     when(client.getOperations()).thenAnswer((_) async => {});
 
     final service = LxdService(client);
     await service.init();
 
-    when(client.getInstances()).thenAnswer((_) async => ['foo', 'bar']);
+    when(client.getInstances()).thenAnswer((_) async => [fooId, barId]);
 
     events.add(LxdEvent(
       type: LxdEventType.operation,
@@ -174,13 +178,13 @@ void main() {
     final events = StreamController<LxdEvent>();
     when(client.getEvents(types: {LxdEventType.operation}))
         .thenAnswer((_) => events.stream);
-    when(client.getInstances()).thenAnswer((_) async => ['foo', 'bar']);
+    when(client.getInstances()).thenAnswer((_) async => [fooId, barId]);
     when(client.getOperations()).thenAnswer((_) async => {});
 
     final service = LxdService(client);
     await service.init();
 
-    when(client.getInstances()).thenAnswer((_) async => ['bar']);
+    when(client.getInstances()).thenAnswer((_) async => [barId]);
 
     events.add(LxdEvent(
       type: LxdEventType.operation,
@@ -203,13 +207,11 @@ void main() {
     final events = StreamController<LxdEvent>();
     when(client.getEvents(types: {LxdEventType.operation}))
         .thenAnswer((_) => events.stream);
-    when(client.getInstances()).thenAnswer((_) async => ['foo', 'bar', 'baz']);
+    when(client.getInstances()).thenAnswer((_) async => [fooId, barId, bazId]);
     when(client.getOperations()).thenAnswer((_) async => {});
 
     final service = LxdService(client);
     await service.init();
-
-    when(client.getInstances()).thenAnswer((_) async => ['foo', 'bar', 'baz']);
 
     events.add(LxdEvent(
       type: LxdEventType.operation,
@@ -255,10 +257,10 @@ void main() {
     final events = StreamController<LxdEvent>();
     when(client.getEvents(types: {LxdEventType.operation}))
         .thenAnswer((_) => events.stream);
-    when(client.getInstances()).thenAnswer((_) async => ['foo', 'bar', 'baz']);
-    when(client.getInstance('foo')).thenAnswer((_) async => foo);
-    when(client.getInstance('bar')).thenAnswer((_) async => bar);
-    when(client.getInstance('baz')).thenAnswer((_) async => baz);
+    when(client.getInstances()).thenAnswer((_) async => [fooId, barId, bazId]);
+    when(client.getInstance(fooId)).thenAnswer((_) async => foo);
+    when(client.getInstance(barId)).thenAnswer((_) async => bar);
+    when(client.getInstance(bazId)).thenAnswer((_) async => baz);
     when(client.getOperations()).thenAnswer((_) async => {
           'pending': ['p'],
           'running': ['r'],
@@ -387,17 +389,17 @@ void main() {
         status: LxdInstanceStatus.running, statusCode: 0, pid: 0, processes: 1);
 
     final client = MockLxdClient();
-    when(client.getInstanceState('foo')).thenAnswer((_) async => state0);
+    when(client.getInstanceState(fooId)).thenAnswer((_) async => state0);
 
     final service = LxdService(client);
     expect(await service.waitVmAgent('foo', timeout: Duration.zero), isFalse);
 
-    when(client.getInstanceState('foo')).thenAnswer((_) async => state1);
+    when(client.getInstanceState(fooId)).thenAnswer((_) async => state1);
     expect(await service.waitVmAgent('foo', timeout: Duration.zero), isTrue);
   });
 
   test('exec terminal', () async {
-    final instance = testInstance(name: 'mine', config: {'user.name': 'me'});
+    final instance = testInstance(name: 'foo', config: {'user.name': 'me'});
 
     final exec = testOperation(id: 'x', metadata: {
       'fds': {
@@ -407,9 +409,9 @@ void main() {
     });
 
     final client = MockLxdClient();
-    when(client.getInstance('mine')).thenAnswer((_) async => instance);
+    when(client.getInstance(fooId)).thenAnswer((_) async => instance);
     when(client.execInstance(
-      'mine',
+      fooId,
       command: ['login', '-f', 'me'],
       environment: {'TERM': 'xterm-256color'},
       interactive: true,
@@ -433,7 +435,7 @@ void main() {
 
     final service = LxdService(client);
 
-    final terminal = await service.execTerminal('mine');
+    final terminal = await service.execTerminal('foo');
     expect(terminal.operation, exec);
     expect(terminal.id, exec.id);
 
@@ -449,9 +451,9 @@ void main() {
     final received = <String>[];
     terminal.listen(received.add);
 
-    verify(client.getInstance('mine')).called(1);
+    verify(client.getInstance(fooId)).called(1);
     verify(client.execInstance(
-      'mine',
+      fooId,
       command: ['login', '-f', 'me'],
       environment: {'TERM': 'xterm-256color'},
       interactive: true,

--- a/packages/lxd_service/test/lxd_service_test.mocks.dart
+++ b/packages/lxd_service/test/lxd_service_test.mocks.dart
@@ -18,8 +18,9 @@ import 'package:lxd/src/api/profile.dart' as _i11;
 import 'package:lxd/src/api/project.dart' as _i12;
 import 'package:lxd/src/api/resource.dart' as _i4;
 import 'package:lxd/src/api/storage_pool.dart' as _i13;
-import 'package:lxd/src/enums.dart' as _i17;
-import 'package:lxd/src/lxd_client.dart' as _i15;
+import 'package:lxd/src/client.dart' as _i15;
+import 'package:lxd/src/enums.dart' as _i18;
+import 'package:lxd/src/instance_id.dart' as _i17;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -360,60 +361,87 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
         returnValue: _i14.Future<List<String>>.value(<String>[]),
       ) as _i14.Future<List<String>>);
   @override
-  _i14.Future<_i6.LxdImage> getImage(String? fingerprint) =>
+  _i14.Future<_i6.LxdImage> getImage(
+    String? fingerprint, {
+    String? project,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #getImage,
           [fingerprint],
+          {#project: project},
         ),
         returnValue: _i14.Future<_i6.LxdImage>.value(_FakeLxdImage_5(
           this,
           Invocation.method(
             #getImage,
             [fingerprint],
+            {#project: project},
           ),
         )),
       ) as _i14.Future<_i6.LxdImage>);
   @override
-  _i14.Future<List<String>> getInstances() => (super.noSuchMethod(
+  _i14.Future<List<_i17.LxdInstanceId>> getInstances({
+    String? project,
+    String? filter,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getInstances,
           [],
+          {
+            #project: project,
+            #filter: filter,
+          },
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue:
+            _i14.Future<List<_i17.LxdInstanceId>>.value(<_i17.LxdInstanceId>[]),
+      ) as _i14.Future<List<_i17.LxdInstanceId>>);
   @override
-  _i14.Future<_i7.LxdInstance> getInstance(String? name) => (super.noSuchMethod(
+  _i14.Future<List<_i17.LxdInstanceId>> getAllInstances({String? filter}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getAllInstances,
+          [],
+          {#filter: filter},
+        ),
+        returnValue:
+            _i14.Future<List<_i17.LxdInstanceId>>.value(<_i17.LxdInstanceId>[]),
+      ) as _i14.Future<List<_i17.LxdInstanceId>>);
+  @override
+  _i14.Future<_i7.LxdInstance> getInstance(_i17.LxdInstanceId? id) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getInstance,
-          [name],
+          [id],
         ),
         returnValue: _i14.Future<_i7.LxdInstance>.value(_FakeLxdInstance_6(
           this,
           Invocation.method(
             #getInstance,
-            [name],
+            [id],
           ),
         )),
       ) as _i14.Future<_i7.LxdInstance>);
   @override
-  _i14.Future<_i8.LxdInstanceState> getInstanceState(String? name) =>
+  _i14.Future<_i8.LxdInstanceState> getInstanceState(_i17.LxdInstanceId? id) =>
       (super.noSuchMethod(
         Invocation.method(
           #getInstanceState,
-          [name],
+          [id],
         ),
         returnValue:
             _i14.Future<_i8.LxdInstanceState>.value(_FakeLxdInstanceState_7(
           this,
           Invocation.method(
             #getInstanceState,
-            [name],
+            [id],
           ),
         )),
       ) as _i14.Future<_i8.LxdInstanceState>);
   @override
   _i14.Future<_i2.LxdOperation> createInstance({
+    String? project,
     String? architecture,
     Map<String, String>? config,
     Map<String, Map<String, String>>? devices,
@@ -433,6 +461,7 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
           #createInstance,
           [],
           {
+            #project: project,
             #architecture: architecture,
             #config: config,
             #devices: devices,
@@ -454,6 +483,7 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
             #createInstance,
             [],
             {
+              #project: project,
               #architecture: architecture,
               #config: config,
               #devices: devices,
@@ -473,27 +503,27 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
       ) as _i14.Future<_i2.LxdOperation>);
   @override
   _i14.Future<_i2.LxdOperation> startInstance(
-    String? name, {
+    _i17.LxdInstanceId? id, {
     bool? force = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #startInstance,
-          [name],
+          [id],
           {#force: force},
         ),
         returnValue: _i14.Future<_i2.LxdOperation>.value(_FakeLxdOperation_1(
           this,
           Invocation.method(
             #startInstance,
-            [name],
+            [id],
             {#force: force},
           ),
         )),
       ) as _i14.Future<_i2.LxdOperation>);
   @override
   _i14.Future<_i2.LxdOperation> execInstance(
-    String? name, {
+    _i17.LxdInstanceId? id, {
     required List<String>? command,
     String? workingDirectory,
     Map<String, String>? environment,
@@ -508,7 +538,7 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
       (super.noSuchMethod(
         Invocation.method(
           #execInstance,
-          [name],
+          [id],
           {
             #command: command,
             #workingDirectory: workingDirectory,
@@ -526,7 +556,7 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
           this,
           Invocation.method(
             #execInstance,
-            [name],
+            [id],
             {
               #command: command,
               #workingDirectory: workingDirectory,
@@ -559,14 +589,14 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
       ) as _i14.Future<_i2.LxdOperation>);
   @override
   _i14.Future<_i2.LxdOperation> stopInstance(
-    String? name, {
+    _i17.LxdInstanceId? id, {
     bool? force = false,
     Duration? timeout,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #stopInstance,
-          [name],
+          [id],
           {
             #force: force,
             #timeout: timeout,
@@ -576,7 +606,7 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
           this,
           Invocation.method(
             #stopInstance,
-            [name],
+            [id],
             {
               #force: force,
               #timeout: timeout,
@@ -586,14 +616,14 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
       ) as _i14.Future<_i2.LxdOperation>);
   @override
   _i14.Future<_i2.LxdOperation> restartInstance(
-    String? name, {
+    _i17.LxdInstanceId? id, {
     bool? force = false,
     Duration? timeout,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #restartInstance,
-          [name],
+          [id],
           {
             #force: force,
             #timeout: timeout,
@@ -603,7 +633,7 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
           this,
           Invocation.method(
             #restartInstance,
-            [name],
+            [id],
             {
               #force: force,
               #timeout: timeout,
@@ -612,74 +642,64 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
         )),
       ) as _i14.Future<_i2.LxdOperation>);
   @override
-  _i14.Future<_i2.LxdOperation> deleteInstance(String? name) =>
+  _i14.Future<_i2.LxdOperation> deleteInstance(_i17.LxdInstanceId? id) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteInstance,
-          [name],
+          [id],
         ),
         returnValue: _i14.Future<_i2.LxdOperation>.value(_FakeLxdOperation_1(
           this,
           Invocation.method(
             #deleteInstance,
-            [name],
+            [id],
           ),
         )),
       ) as _i14.Future<_i2.LxdOperation>);
   @override
   _i14.Future<String> pullFile(
-    String? instance, {
+    _i17.LxdInstanceId? id, {
     required String? path,
-    String? project,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #pullFile,
-          [instance],
-          {
-            #path: path,
-            #project: project,
-          },
+          [id],
+          {#path: path},
         ),
         returnValue: _i14.Future<String>.value(''),
       ) as _i14.Future<String>);
   @override
   _i14.Future<void> deleteFile(
-    String? instance, {
+    _i17.LxdInstanceId? id, {
     required String? path,
-    String? project,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteFile,
-          [instance],
-          {
-            #path: path,
-            #project: project,
-          },
+          [id],
+          {#path: path},
         ),
         returnValue: _i14.Future<void>.value(),
         returnValueForMissingStub: _i14.Future<void>.value(),
       ) as _i14.Future<void>);
   @override
   _i14.Future<void> pushFile(
-    String? instance, {
+    _i17.LxdInstanceId? id, {
     required String? path,
-    String? project,
     String? data,
     int? uid,
     int? gid,
     String? mode,
-    _i17.LxdFileType? type,
-    _i17.LxdWriteMode? write,
+    _i18.LxdFileType? type,
+    _i18.LxdWriteMode? write,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #pushFile,
-          [instance],
+          [id],
           {
             #path: path,
-            #project: project,
             #data: data,
             #uid: uid,
             #gid: gid,
@@ -740,19 +760,25 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
         )),
       ) as _i14.Future<_i9.LxdNetworkState>);
   @override
-  _i14.Future<List<String>> getNetworkAcls() => (super.noSuchMethod(
+  _i14.Future<List<String>> getNetworkAcls({String? project}) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getNetworkAcls,
           [],
+          {#project: project},
         ),
         returnValue: _i14.Future<List<String>>.value(<String>[]),
       ) as _i14.Future<List<String>>);
   @override
-  _i14.Future<_i10.LxdNetworkAcl> getNetworkAcl(String? name) =>
+  _i14.Future<_i10.LxdNetworkAcl> getNetworkAcl(
+    String? name, {
+    String? project,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #getNetworkAcl,
           [name],
+          {#project: project},
         ),
         returnValue:
             _i14.Future<_i10.LxdNetworkAcl>.value(_FakeLxdNetworkAcl_10(
@@ -760,28 +786,37 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
           Invocation.method(
             #getNetworkAcl,
             [name],
+            {#project: project},
           ),
         )),
       ) as _i14.Future<_i10.LxdNetworkAcl>);
   @override
-  _i14.Future<List<String>> getProfiles() => (super.noSuchMethod(
+  _i14.Future<List<String>> getProfiles({String? project}) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getProfiles,
           [],
+          {#project: project},
         ),
         returnValue: _i14.Future<List<String>>.value(<String>[]),
       ) as _i14.Future<List<String>>);
   @override
-  _i14.Future<_i11.LxdProfile> getProfile(String? name) => (super.noSuchMethod(
+  _i14.Future<_i11.LxdProfile> getProfile(
+    String? name, {
+    String? project,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getProfile,
           [name],
+          {#project: project},
         ),
         returnValue: _i14.Future<_i11.LxdProfile>.value(_FakeLxdProfile_11(
           this,
           Invocation.method(
             #getProfile,
             [name],
+            {#project: project},
           ),
         )),
       ) as _i14.Future<_i11.LxdProfile>);
@@ -808,19 +843,25 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
         )),
       ) as _i14.Future<_i12.LxdProject>);
   @override
-  _i14.Future<List<String>> getStoragePools() => (super.noSuchMethod(
+  _i14.Future<List<String>> getStoragePools({String? project}) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getStoragePools,
           [],
+          {#project: project},
         ),
         returnValue: _i14.Future<List<String>>.value(<String>[]),
       ) as _i14.Future<List<String>>);
   @override
-  _i14.Future<_i13.LxdStoragePool> getStoragePool(String? name) =>
+  _i14.Future<_i13.LxdStoragePool> getStoragePool(
+    String? name, {
+    String? project,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #getStoragePool,
           [name],
+          {#project: project},
         ),
         returnValue:
             _i14.Future<_i13.LxdStoragePool>.value(_FakeLxdStoragePool_13(
@@ -828,6 +869,7 @@ class MockLxdClient extends _i1.Mock implements _i15.LxdClient {
           Invocation.method(
             #getStoragePool,
             [name],
+            {#project: project},
           ),
         )),
       ) as _i14.Future<_i13.LxdStoragePool>);

--- a/packages/lxd_test/pubspec.yaml
+++ b/packages/lxd_test/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: 9799464c4488f52203407169baca963f88f0e349
+      ref: 48f586befd7a4229ccf2b25b7b6e7590214db03d
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/lxd_x/lib/lxd_x.dart
+++ b/packages/lxd_x/lib/lxd_x.dart
@@ -19,22 +19,22 @@ String resolveLxdSocketPath([String? socketPath]) {
 }
 
 extension LxdClientX on LxdClient {
-  Future<void> mkdir(String instance, String path) async {
-    final op = await execInstance(instance, command: ['mkdir', '-p', path]);
+  Future<void> mkdir(LxdInstanceId id, String path) async {
+    final op = await execInstance(id, command: ['mkdir', '-p', path]);
     await waitOperation(op.id);
   }
 
-  Future<String> uid(String instance, String username) {
-    return _exec(instance, ['id', '-u', username]);
+  Future<String> uid(LxdInstanceId id, String username) {
+    return _exec(id, ['id', '-u', username]);
   }
 
-  Future<String> gid(String instance, String username) {
-    return _exec(instance, ['id', '-g', username]);
+  Future<String> gid(LxdInstanceId id, String username) {
+    return _exec(id, ['id', '-g', username]);
   }
 
-  Future<String> _exec(String instance, List<String> command) async {
+  Future<String> _exec(LxdInstanceId id, List<String> command) async {
     final exec = await execInstance(
-      instance,
+      id,
       command: command,
       interactive: true,
       waitForWebSocket: true,

--- a/packages/lxd_x/pubspec.yaml
+++ b/packages/lxd_x/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: 9799464c4488f52203407169baca963f88f0e349
+      ref: 48f586befd7a4229ccf2b25b7b6e7590214db03d
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: 9799464c4488f52203407169baca963f88f0e349
+      ref: 48f586befd7a4229ccf2b25b7b6e7590214db03d
   lxd_service:
     path: packages/lxd_service
   lxd_test:


### PR DESCRIPTION
Instead of passing around instance names, instances are now identified by `LxdInstanceId` which is a combination of the instance's name _and_ project. For the time being, `LxdService` hides that detail from the GUI but the IDs will be gradually exposed as necessary for handling projects in the GUI.

Ref: #186