### PR TITLE
InstanceStore: remove unused instance states

### DIFF
--- a/lib/home/instance_context.dart
+++ b/lib/home/instance_context.dart
@@ -8,9 +8,4 @@ extension InstanceContext on BuildContext {
   LxdInstance? selectInstance(String name) {
     return select<InstanceStore, LxdInstance?>((s) => s.getInstance(name));
   }
-
-  LxdInstanceState? selectInstanceState(String name) {
-    return select<InstanceStore, LxdInstanceState?>(
-        (s) => s.getInstanceState(name));
-  }
 }

--- a/lib/home/instance_store.dart
+++ b/lib/home/instance_store.dart
@@ -15,12 +15,10 @@ class InstanceStore extends SafeChangeNotifier {
   List<StreamSubscription>? _subs;
   var _instances = const InstanceList.data([]);
   final _values = <String, LxdInstance>{};
-  final _states = <String, LxdInstanceState>{};
 
   InstanceList get instances => _instances;
 
   LxdInstance? getInstance(String instance) => _values[instance];
-  LxdInstanceState? getInstanceState(String instance) => _states[instance];
 
   @protected
   set instances(InstanceList instances) {
@@ -49,17 +47,14 @@ class InstanceStore extends SafeChangeNotifier {
 
   Future<void> _update(String name) async {
     final value = await _service.getInstance(name);
-    final state = await _service.getInstanceState(name);
     if (value != _values[name]) {
       _values[name] = value;
-      _states[name] = state;
       notifyListeners();
     }
   }
 
   Future<void> _remove(String name) async {
     if (_values.remove(name) != null) {
-      _states.remove(name);
       notifyListeners();
     }
   }


### PR DESCRIPTION
It was an oversight to add state-API to the instance store because unlike instance objects, state objects won't be kept up-to-date. The backend is not emitting any change signals - the instance info dialog uses a timer instead to periodically refresh the state.