### PR TITLE
testInstance(): use LxdInstanceId instead of plain name

### DIFF
--- a/packages/lxd_service/pubspec.yaml
+++ b/packages/lxd_service/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: db51ab2d9a28bb6cef319bd86b12f00b3814355e
+      ref: c49f4db628d66ef6f18067caf0c010a404166fd3
   lxd_test:
     path: ../lxd_test
   lxd_x:

--- a/packages/lxd_service/test/lxd_service_test.dart
+++ b/packages/lxd_service/test/lxd_service_test.dart
@@ -230,9 +230,9 @@ void main() {
   });
 
   test('instance status', () async {
-    final foo = testInstance(name: 'foo');
-    final bar = testInstance(name: 'bar');
-    final baz = testInstance(name: 'baz');
+    final foo = testInstance(id: fooId);
+    final bar = testInstance(id: barId);
+    final baz = testInstance(id: bazId);
 
     final starting = testOperation(
       id: 'p',
@@ -399,7 +399,7 @@ void main() {
   });
 
   test('exec terminal', () async {
-    final instance = testInstance(name: 'foo', config: {'user.name': 'me'});
+    final instance = testInstance(id: fooId, config: {'user.name': 'me'});
 
     final exec = testOperation(id: 'x', metadata: {
       'fds': {

--- a/packages/lxd_service/test/lxd_service_test.dart
+++ b/packages/lxd_service/test/lxd_service_test.dart
@@ -294,7 +294,8 @@ void main() {
   test('watch instance', () async {
     final client = MockLxdClient();
     final events = StreamController<LxdEvent>();
-    when(client.getEvents()).thenAnswer((_) => events.stream);
+    when(client.getEvents(project: fooId.project))
+        .thenAnswer((_) => events.stream);
 
     final service = LxdService(client);
     final stream = service.watchInstance(fooId);

--- a/packages/lxd_test/lib/lxd_test.dart
+++ b/packages/lxd_test/lib/lxd_test.dart
@@ -25,7 +25,7 @@ LxdImage testImage({
 }
 
 LxdInstance testInstance({
-  required String name,
+  required LxdInstanceId id,
   int? statusCode,
   Map<String, String>? config,
 }) {
@@ -40,9 +40,9 @@ LxdInstance testInstance({
     expandedDevices: {},
     lastUsedAt: DateTime.now(),
     location: '',
-    name: name,
+    name: id.name,
     profiles: [],
-    project: '',
+    project: id.project,
     restore: '',
     stateful: false,
     status: '',

--- a/packages/lxd_test/pubspec.yaml
+++ b/packages/lxd_test/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: db51ab2d9a28bb6cef319bd86b12f00b3814355e
+      ref: c49f4db628d66ef6f18067caf0c010a404166fd3
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/lxd_x/pubspec.yaml
+++ b/packages/lxd_x/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: db51ab2d9a28bb6cef319bd86b12f00b3814355e
+      ref: c49f4db628d66ef6f18067caf0c010a404166fd3
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   lxd:
     git:
       url: https://github.com/jpnurmi/lxd.dart
-      ref: db51ab2d9a28bb6cef319bd86b12f00b3814355e
+      ref: c49f4db628d66ef6f18067caf0c010a404166fd3
   lxd_service:
     path: packages/lxd_service
   lxd_test:

--- a/test/instance_info_model_test.dart
+++ b/test/instance_info_model_test.dart
@@ -15,7 +15,7 @@ void main() {
     fakeAsync((async) {
       const instanceId = LxdInstanceId('foo');
       const updateInterval = Duration(milliseconds: 10);
-      final instance = testInstance(name: instanceId.name);
+      final instance = testInstance(id: instanceId);
       final instanceState = testInstanceState();
       final service = MockLxdService();
 

--- a/test/terminal_manager_test.dart
+++ b/test/terminal_manager_test.dart
@@ -15,7 +15,7 @@ import 'terminal_manager_test.mocks.dart';
 void main() {
   test('life-cycle', () async {
     final key = Object();
-    final instance = testInstance(name: 'test');
+    final instance = testInstance(id: const LxdInstanceId('test'));
 
     final start = testOperation(id: 'start');
     final exec = testOperation(id: 'exec');


### PR DESCRIPTION
To avoid forcing empty project names in tests.