### PR TITLE
OsLogo: guard against accessing the context when no longer mounted

### DIFF
--- a/packages/os_logo/lib/src/os_logo.dart
+++ b/packages/os_logo/lib/src/os_logo.dart
@@ -41,6 +41,7 @@ class _OsLogoState extends State<OsLogo> {
   }
 
   Future<String?> _tryLoadSvg(String name) async {
+    if (!mounted) return null;
     final bundle = DefaultAssetBundle.of(context);
     try {
       return await bundle.loadString('packages/os_logo/assets/$name.svg');
@@ -50,7 +51,7 @@ class _OsLogoState extends State<OsLogo> {
 
   Future<String?> _loadSvg() async {
     final name = widget.name?.toLowerCase();
-    if (name != null) {
+    if (mounted && name != null) {
       final brightness = Theme.of(context).brightness.name;
       return await _tryLoadSvg('$name-$brightness') ?? await _tryLoadSvg(name);
     }


### PR DESCRIPTION
The SVG loading operations are asynchronous. We must not try to access `DefaultAssetBundle.of(context)` or `Theme.of(context)` when quickly scrolling long instance lists back and forth so that tiles get removed from the widget tree during SVG lookups or loading.

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
#0      State.context.<anonymous closure>
package:flutter/…/widgets/framework.dart:935
#1      State.context
package:flutter/…/widgets/framework.dart:941
#2      _OsLogoState._tryLoadSvg
package:os_logo/src/os_logo.dart:44
#3      _OsLogoState._loadSvg
package:os_logo/src/os_logo.dart:55
<asynchronous suspension>
#4      _OsLogoState._updateSvg
```

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
#0      State.context.<anonymous closure>
package:flutter/…/widgets/framework.dart:935
#1      State.context
package:flutter/…/widgets/framework.dart:941
#2      _OsLogoState._loadSvg
package:os_logo/src/os_logo.dart:55
#3      _OsLogoState._updateSvg
package:os_logo/src/os_logo.dart:38
#4      _OsLogoState.initState.<anonymous closure>
package:os_logo/src/os_logo.dart:20
#5      SchedulerBinding._invokeFrameCallback
package:flutter/…/scheduler/binding.dart:1175
#6      SchedulerBinding.handleDrawFrame
package:flutter/…/scheduler/binding.dart:1113
#7      SchedulerBinding._handleDrawFrame
package:flutter/…/scheduler/binding.dart:1015
#8      _invoke (dart:ui/hooks.dart:148:13)
#9      PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:318:5)
#10     _drawFrame (dart:ui/hooks.dart:115:31)
```