### PR TITLE
Use YaruBorderContainer in favor of RoundedContainer

### DIFF
--- a/lib/launcher/feature_page.dart
+++ b/lib/launcher/feature_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lxd_service/lxd_service.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'feature_model.dart';
 import 'launcher_l10n.dart';
@@ -39,7 +39,8 @@ class _FeaturePageState extends State<FeaturePage> {
     final l10n = AppLocalizations.of(context);
     return LauncherPage(
       title: Text(l10n.selectFeaturesTitle),
-      content: RoundedContainer(
+      content: YaruBorderContainer(
+        color: Theme.of(context).backgroundColor,
         child: ListView(
           children: [
             if (LxdFeature.user.isSupported(model.type))

--- a/lib/launcher/local_image_page.dart
+++ b/lib/launcher/local_image_page.dart
@@ -6,8 +6,8 @@ import 'package:lxd/lxd.dart';
 import 'package:lxd_x/lxd_x.dart';
 import 'package:os_logo/os_logo.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../remotes/remote_selector.dart';
 import 'launcher_page.dart';
@@ -51,7 +51,8 @@ class LocalImageView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final model = context.watch<LocalImageModel>();
-    return RoundedContainer(
+    return YaruBorderContainer(
+      color: Theme.of(context).backgroundColor,
       child: model.images?.when(
         data: (images) => _LocalImageView(
           images: images,

--- a/lib/launcher/progress_page.dart
+++ b/lib/launcher/progress_page.dart
@@ -5,8 +5,8 @@ import 'package:lxd_service/lxd_service.dart';
 import 'package:lxd_x/lxd_x.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../remotes/remote_store.dart';
 import 'progress_model.dart';
@@ -120,7 +120,8 @@ class _ProgressViewState extends State<_ProgressView> {
         Expanded(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24),
-            child: RoundedContainer(
+            child: YaruBorderContainer(
+              color: Theme.of(context).backgroundColor,
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [

--- a/lib/launcher/property_page.dart
+++ b/lib/launcher/property_page.dart
@@ -4,8 +4,8 @@ import 'package:lxd_service/lxd_service.dart';
 import 'package:os_logo/os_logo.dart';
 import 'package:provider/provider.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'launcher_model.dart';
 import 'launcher_page.dart';
@@ -51,7 +51,8 @@ class _PropertyPageState extends State<PropertyPage> {
     final l10n = AppLocalizations.of(context);
     return LauncherPage(
       title: Text(l10n.launchInstanceTitle),
-      content: RoundedContainer(
+      content: YaruBorderContainer(
+        color: Theme.of(context).backgroundColor,
         child: Padding(
           padding: const EdgeInsets.all(48),
           child: Row(

--- a/lib/launcher/remote_image_page.dart
+++ b/lib/launcher/remote_image_page.dart
@@ -5,8 +5,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lxd/lxd.dart';
 import 'package:os_logo/os_logo.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'launcher_l10n.dart';
 import 'launcher_model.dart';
@@ -36,7 +36,8 @@ class RemoteImagePage extends StatelessWidget {
 
     return LauncherPage(
       title: Text(l10n.selectImageTitle),
-      content: RoundedContainer(
+      content: YaruBorderContainer(
+        color: Theme.of(context).backgroundColor,
         child: Padding(
           padding: const EdgeInsets.all(48),
           child: images?.when(

--- a/lib/launcher/remote_os_page.dart
+++ b/lib/launcher/remote_os_page.dart
@@ -2,8 +2,8 @@ import 'package:async_value/async_value.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:wizard_router/wizard_router.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '../remotes/remote_selector.dart';
 import 'launcher_page.dart';
@@ -19,7 +19,8 @@ class RemoteOsPage extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     return LauncherPage(
       title: Text(l10n.selectOsTitle),
-      content: RoundedContainer(
+      content: YaruBorderContainer(
+        color: Theme.of(context).backgroundColor,
         child: model.images?.when(
           data: (images) => OsSelector(
             items: model.oses,

--- a/lib/preferences/preferences_dialog.dart
+++ b/lib/preferences/preferences_dialog.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:title_bar/title_bar.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
-import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'appearance_view.dart';
@@ -75,7 +74,8 @@ class PreferencesDialog extends StatelessWidget {
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.all(24),
-                  child: RoundedContainer(
+                  child: YaruBorderContainer(
+                    color: Theme.of(context).backgroundColor,
                     child: YaruMasterDetailPage(
                       length: preferences.length,
                       tileBuilder: (context, index, selected) => YaruMasterTile(


### PR DESCRIPTION
Looks similar but the border color is slightly softer and the border-radius is a bit larger. It also has no default background color but we can set that to keep the looks almost identical.

| Before | After |
|---|---|
| ![Screenshot from 2022-11-30 16-19-25](https://user-images.githubusercontent.com/140617/204838424-d8334a2b-7c68-4963-b895-fe12952b1bb3.png) | ![Screenshot from 2022-11-30 16-20-30](https://user-images.githubusercontent.com/140617/204838430-f7da68eb-ec60-4fdb-ae1b-84332bfaf767.png) |