### PR TITLE
Pin freezed at version 2.2.1

### DIFF
--- a/packages/lxd/pubspec.yaml
+++ b/packages/lxd/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.10
-  freezed: ^2.0.3+1
+  freezed: 2.2.1
   json_serializable: ^6.2.0
   lints: ^2.0.0
   mockito: ^5.1.0

--- a/packages/lxd_service/pubspec.yaml
+++ b/packages/lxd_service/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.11
-  freezed: ^2.0.3+1
+  freezed: 2.2.1
   json_serializable: ^6.2.0
   lints: ^2.0.0
   mockito: 5.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,7 +86,7 @@ dev_dependencies:
   flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
-  freezed: ^2.0.3+1
+  freezed: 2.2.1
   json_serializable: ^6.2.0
   mockito: 5.3.2
 


### PR DESCRIPTION
2.3.0 generates broken code:

    error • '_$$LxdAsyncResponseCopyWith.call' ('$Res Function({Map<String, dynamic> metadata, String operation, String status, int statusCode})') isn't a valid override of '$LxdResponseCopyWith.call' ('$Res Function({dynamic metadata})') • lib/src/response.freezed.dart:340:8 • invalid_override
    error • '_$$LxdErrorResponseCopyWith.call' ('$Res Function({String error, int errorCode, Map<String, dynamic>? metadata})') isn't a valid override of '$LxdResponseCopyWith.call' ('$Res Function({dynamic metadata})') • lib/src/response.freezed.dart:563:8 • invalid_override