### PR TITLE
Share instance "summary" for searching and filtering

### DIFF
--- a/lib/home/instance_table_row.dart
+++ b/lib/home/instance_table_row.dart
@@ -53,7 +53,7 @@ class _InstanceLabel extends StatelessWidget {
     final instance = context.selectInstance(id);
     return Row(
       children: [
-        OsLogo.asset(name: instance?.imageName, size: 36),
+        OsLogo.asset(name: instance?.os?.toLowerCase(), size: 36),
         Expanded(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -61,7 +61,7 @@ class _InstanceLabel extends StatelessWidget {
             children: [
               Text(instance?.name ?? '', overflow: TextOverflow.ellipsis),
               Text(
-                instance?.imageDescription ?? '',
+                instance?.summary ?? '',
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodySmall,
               ),
@@ -71,11 +71,6 @@ class _InstanceLabel extends StatelessWidget {
       ],
     );
   }
-}
-
-extension _LxdInstanceImage on LxdInstance {
-  String? get imageName => config['image.os']?.toLowerCase();
-  String? get imageDescription => config['image.description'];
 }
 
 class _InstanceButtons extends StatelessWidget {

--- a/packages/lxd_x/lib/lxd_x.dart
+++ b/packages/lxd_x/lib/lxd_x.dart
@@ -20,6 +20,8 @@ extension LxdImageX on LxdImage {
 
 extension LxdInstanceX on LxdInstance {
   String? get os => config['image.os'];
+  String? get summary =>
+      description.isEmpty ? config['image.description'] : description;
 
   bool get isBusy => isStarting || isStopping;
   bool get isStarting => statusCode == LxdStatusCode.starting;


### PR DESCRIPTION
It's either the instance's description if explicitly set (currently not set for instances created by Workshops) or fall back to the source image's description. This is the subtitle shown on the home screen and thus, would be nice to include the logic in the upcoming search.