### PR TITLE
Fix fully transparent window on startup

### DIFF
--- a/lib/terminal/terminal_page.dart
+++ b/lib/terminal/terminal_page.dart
@@ -6,6 +6,7 @@ import 'package:nested_split_view/nested_split_view.dart';
 import 'package:provider/provider.dart';
 import 'package:terminal_view/terminal_view.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:window_manager/window_manager.dart';
 
 import '../settings.dart';
 import 'terminal_commands.dart';
@@ -55,6 +56,8 @@ class _TerminalPageState extends State<_TerminalPage>
   @override
   void initState() {
     super.initState();
+
+    windowManager.setBackgroundColor(Colors.transparent);
 
     final manager = context.read<TerminalManager>();
     manager.listen(

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -43,7 +43,6 @@ static void my_application_activate(GApplication* application) {
   if (gdk_screen_is_composited(screen)) {
     GdkVisual* visual = gdk_screen_get_rgba_visual(screen);
     if (visual != nullptr) {
-      gtk_widget_set_app_paintable(GTK_WIDGET(window), true);
       gtk_widget_set_visual(GTK_WIDGET(window), visual);
     }
   }

--- a/packages/title_bar/pubspec.yaml
+++ b/packages/title_bar/pubspec.yaml
@@ -8,7 +8,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  window_manager: ^0.2.7
+  window_manager: # TODO: ^0.2.9
+    git:
+      ref: b8188c800928afdbcec1dc0ff3e680c466e9a053
+      url: https://github.com/leanflutter/window_manager
   yaru_icons: ^0.2.6
   yaru_widgets: # TODO: ^2.0.0
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,10 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/ubuntu_widgets
+  window_manager: # TODO: ^0.2.9
+    git:
+      ref: b8188c800928afdbcec1dc0ff3e680c466e9a053
+      url: https://github.com/leanflutter/window_manager
   wizard_router: ^0.9.0
   xdg_directories: ^0.2.0+2
   yaml: ^3.1.1


### PR DESCRIPTION
Keep the opaque window during startup. Post-pone transparent window background until entering a terminal.

Close: #257