### PR TITLE
Fix keyboard search & shortcuts to work together

### DIFF
--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -1,4 +1,3 @@
-import 'package:command_store/command_store.dart';
 import 'package:context_menu/context_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:lxd/lxd.dart';
@@ -16,27 +15,24 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Shortcuts(
-      shortcuts: CommandStore.shortcutsOf(context),
-      child: Scaffold(
-        body: ContextMenuArea(
-          builder: (context, position) => buildHomeMenu(context: context),
-          child: Actions(
-            actions: {
-              SelectInstanceIntent: SelectInstanceAction(onSelected),
-            },
-            child: const InstanceTableView(),
-          ),
-        ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () async {
-            final instance = await showLauncherWizard(context);
-            if (instance != null) {
-              onSelected(instance);
-            }
+    return Scaffold(
+      body: ContextMenuArea(
+        builder: (context, position) => buildHomeMenu(context: context),
+        child: Actions(
+          actions: {
+            SelectInstanceIntent: SelectInstanceAction(onSelected),
           },
-          child: const Icon(Icons.add),
+          child: const InstanceTableView(),
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final instance = await showLauncherWizard(context);
+          if (instance != null) {
+            onSelected(instance);
+          }
+        },
+        child: const Icon(Icons.add),
       ),
     );
   }


### PR DESCRIPTION
Before this PR, `Ctrl`+`Shift`+`K` in the home screen would open the search box and enter "K". After this PR, it opens the command palette as it used to before #268.

Shortcuts have to be defined below the key search handler to ensure that they get handled first.

Fixes: #274