### PR TITLE
Rename custom config entries

### DIFF
--- a/lib/launcher/feature_model.dart
+++ b/lib/launcher/feature_model.dart
@@ -45,14 +45,15 @@ class FeatureModel extends SafeChangeNotifier {
     return _image.copyWith(
       properties: {
         ..._image.properties,
-        'user.features': _features.map((f) => f.name).join(','),
-        'user.name': user ?? 'root',
-        'user.shell': Platform.environment['SHELL'] ?? '',
-        'user.home': home ?? '/root',
-        'user.gpu': 'physical',
-        'user.x11': Platform.environment['DISPLAY'] ?? ':0',
-        'user.wayland': Platform.environment['WAYLAND_DISPLAY'] ?? 'wayland-0',
-        'user.lxd': LxdClient.resolveUnixSocket().path,
+        'user.workshops.features': _features.map((f) => f.name).join(','),
+        'user.workshops.name': user ?? 'root',
+        'user.workshops.shell': Platform.environment['SHELL'] ?? '',
+        'user.workshops.home': home ?? '/root',
+        'user.workshops.gpu': 'physical',
+        'user.workshops.x11': Platform.environment['DISPLAY'] ?? ':0',
+        'user.workshops.wayland':
+            Platform.environment['WAYLAND_DISPLAY'] ?? 'wayland-0',
+        'user.workshops.lxd': LxdClient.resolveUnixSocket().path,
       },
     );
   }

--- a/lib/launcher/progress_model.dart
+++ b/lib/launcher/progress_model.dart
@@ -57,7 +57,7 @@ class ProgressModel extends SafeChangeNotifier {
       return started;
     }
 
-    final features = image.properties['user.features']
+    final features = image.properties['user.workshops.features']
             ?.split(',')
             .map((name) => LxdFeature.values.byName(name)) ??
         {};

--- a/packages/lxd_service/lib/src/features.dart
+++ b/packages/lxd_service/lib/src/features.dart
@@ -38,12 +38,12 @@ mixin LxdFeatureService on LxdClient {
   }
 
   Future<LxdImage> configureImage(LxdInstanceId id, LxdImage image) async {
-    final username = image.properties['user.name']!;
+    final username = image.properties['user.workshops.name']!;
     return image.copyWith(
       properties: {
         ...image.properties,
-        'user.uid': await _runCommand(id, ['id', '-u', username]),
-        'user.gid': await _runCommand(id, ['id', '-g', username]),
+        'user.workshops.uid': await _runCommand(id, ['id', '-u', username]),
+        'user.workshops.gid': await _runCommand(id, ['id', '-g', username]),
       },
     );
   }

--- a/packages/lxd_service/lib/src/features/audio.dart
+++ b/packages/lxd_service/lib/src/features/audio.dart
@@ -34,8 +34,8 @@ class LxdAudioFeature extends LxdFeatureProvider {
 
   @override
   Map<String, Map<String, String>> getDevices(LxdImage image) {
-    final uid = image.properties['user.uid']!;
-    final gid = image.properties['user.gid']!;
+    final uid = image.properties['user.workshops.uid']!;
+    final gid = image.properties['user.workshops.gid']!;
 
     return {
       'pulse': {

--- a/packages/lxd_service/lib/src/features/graphics.dart
+++ b/packages/lxd_service/lib/src/features/graphics.dart
@@ -17,8 +17,8 @@ class LxdGraphicsFeature extends LxdFeatureProvider {
 
   @override
   Map<String, String> getFiles(LxdImage image) {
-    final x11 = image.properties['user.x11']!;
-    final wayland = image.properties['user.wayland']!;
+    final x11 = image.properties['user.workshops.x11']!;
+    final wayland = image.properties['user.workshops.wayland']!;
 
     return {
       '/etc/profile.d/workshops-graphics.sh': '''
@@ -32,10 +32,10 @@ class LxdGraphicsFeature extends LxdFeatureProvider {
 
   @override
   Map<String, Map<String, String>> getDevices(LxdImage image) {
-    final gpu = image.properties['user.gpu']!;
-    final x11 = image.properties['user.x11']!;
-    final uid = image.properties['user.uid']!;
-    final gid = image.properties['user.gid']!;
+    final gpu = image.properties['user.workshops.gpu']!;
+    final x11 = image.properties['user.workshops.x11']!;
+    final uid = image.properties['user.workshops.uid']!;
+    final gid = image.properties['user.workshops.gid']!;
 
     return {
       'gpu': {

--- a/packages/lxd_service/lib/src/features/home.dart
+++ b/packages/lxd_service/lib/src/features/home.dart
@@ -7,7 +7,7 @@ class LxdHomeFeature extends LxdFeatureProvider {
 
   @override
   Map<String, Map<String, String>> getDevices(LxdImage image) {
-    final home = image.properties['user.home']!;
+    final home = image.properties['user.workshops.home']!;
 
     return {
       'home': {

--- a/packages/lxd_service/lib/src/features/server.dart
+++ b/packages/lxd_service/lib/src/features/server.dart
@@ -28,9 +28,9 @@ class LxdServerFeature extends LxdFeatureProvider {
 
   @override
   Map<String, Map<String, String>> getDevices(LxdImage image) {
-    final lxd = image.properties['user.lxd']!;
-    final uid = image.properties['user.uid']!;
-    final gid = image.properties['user.gid']!;
+    final lxd = image.properties['user.workshops.lxd']!;
+    final uid = image.properties['user.workshops.uid']!;
+    final gid = image.properties['user.workshops.gid']!;
 
     return {
       'lxd': {

--- a/packages/lxd_service/lib/src/features/user.dart
+++ b/packages/lxd_service/lib/src/features/user.dart
@@ -12,7 +12,7 @@ class LxdUserFeature extends LxdFeatureProvider {
 
   @override
   Map<String, String> getFiles(LxdImage image) {
-    final username = image.properties['user.name']!;
+    final username = image.properties['user.workshops.name']!;
 
     return {
       '/etc/sudoers.d/90-workshops': '''
@@ -26,12 +26,12 @@ class LxdUserFeature extends LxdFeatureProvider {
 
   @override
   Map<String, String> getConfig(LxdImage image) {
-    final username = image.properties['user.name']!;
-    final uid = image.properties['user.uid']!;
-    final gid = image.properties['user.gid']!;
+    final username = image.properties['user.workshops.name']!;
+    final uid = image.properties['user.workshops.uid']!;
+    final gid = image.properties['user.workshops.gid']!;
 
     return {
-      'user.name': username,
+      'user.workshops.name': username,
       'raw.idmap': '''
 uid ${getuid()} $uid
 gid ${getgid()} $gid
@@ -42,8 +42,8 @@ gid ${getgid()} $gid
   @override
   Future<LxdOperation?> init(
       LxdClient client, LxdInstance instance, LxdImage image) async {
-    final username = image.properties['user.name']!;
-    final shell = image.properties['user.shell'];
+    final username = image.properties['user.workshops.name']!;
+    final shell = image.properties['user.workshops.shell'];
 
     // sudo vs. wheel
     final group =

--- a/packages/lxd_service/lib/src/terminal.dart
+++ b/packages/lxd_service/lib/src/terminal.dart
@@ -8,7 +8,7 @@ import 'package:meta/meta.dart';
 mixin LxdTerminalService on LxdClient {
   Future<LxdTerminal> execTerminal(LxdInstanceId id) async {
     final instance = await getInstance(id);
-    final user = instance.config['user.name'] ?? 'root';
+    final user = instance.config['user.workshops.name'] ?? 'root';
     final op = await execInstance(
       instance.id,
       command: ['login', '-f', user],

--- a/packages/lxd_service/test/lxd_terminal_service_test.dart
+++ b/packages/lxd_service/test/lxd_terminal_service_test.dart
@@ -13,7 +13,8 @@ class TestLxdTerminalService extends MockLxdClient with LxdTerminalService {}
 
 void main() {
   test('exec terminal', () async {
-    final instance = testInstance(id: fooId, config: {'user.name': 'me'});
+    final instance =
+        testInstance(id: fooId, config: {'user.workshops.name': 'me'});
 
     final exec = testOperation(id: 'x', metadata: {
       'fds': {


### PR DESCRIPTION
Change `user.*` to ` user.workshops.*` in order to avoid unnecessary pollution of user configuration entries. Also enables us to hide our custom settings in the UI