### PR TITLE
Add splash screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,8 +16,11 @@ import 'launcher/remote_image_model.dart';
 import 'path_provider.dart';
 import 'remotes/remote_store.dart';
 import 'settings.dart';
+import 'splash.dart';
 
 Future<void> main() async {
+  runApp(const Splash());
+
   Logger.setup(level: LogLevel.fromString(kDebugMode ? 'debug' : 'info'));
 
   final service = LxdService();

--- a/lib/splash.dart
+++ b/lib/splash.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:title_bar/title_bar.dart';
+import 'package:yaru/yaru.dart';
+
+class Splash extends StatelessWidget {
+  const Splash({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: yaruLight,
+      darkTheme: yaruDark,
+      highContrastTheme: yaruHighContrastLight,
+      highContrastDarkTheme: yaruHighContrastDark,
+      home: Scaffold(
+        appBar: WindowTitleBar(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
It's an empty `MaterialApp`+`Scaffold`+`WindowTitleBar` with Yaru theme to bring something minimal with a titlebar visible as soon as possible on app startup.