### PR TITLE
LXD: enable `any_map` for `json_serializable`

### DIFF
--- a/packages/lxd/build.yaml
+++ b/packages/lxd/build.yaml
@@ -3,5 +3,6 @@ targets:
     builders:
       json_serializable:
         options:
+          any_map: true
           explicit_to_json: true
           field_rename: snake

--- a/packages/lxd/lib/src/api/certificate.g.dart
+++ b/packages/lxd/lib/src/api/certificate.g.dart
@@ -6,8 +6,7 @@ part of 'certificate.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdCertificate _$$_LxdCertificateFromJson(Map<String, dynamic> json) =>
-    _$_LxdCertificate(
+_$_LxdCertificate _$$_LxdCertificateFromJson(Map json) => _$_LxdCertificate(
       name: json['name'] as String,
       type: $enumDecode(_$LxdCertificateTypeEnumMap, json['type'],
           unknownValue: LxdCertificateType.unknown),

--- a/packages/lxd/lib/src/api/event.g.dart
+++ b/packages/lxd/lib/src/api/event.g.dart
@@ -6,10 +6,12 @@ part of 'event.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdEvent _$$_LxdEventFromJson(Map<String, dynamic> json) => _$_LxdEvent(
+_$_LxdEvent _$$_LxdEventFromJson(Map json) => _$_LxdEvent(
       type: $enumDecode(_$LxdEventTypeEnumMap, json['type']),
       timestamp: DateTime.parse(json['timestamp'] as String),
-      metadata: json['metadata'] as Map<String, dynamic>?,
+      metadata: (json['metadata'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, e),
+      ),
       location: json['location'] as String?,
       project: json['project'] as String?,
     );
@@ -29,8 +31,7 @@ const _$LxdEventTypeEnumMap = {
   LxdEventType.lifecycle: 'lifecycle',
 };
 
-_$_LxdEventLogging _$$_LxdEventLoggingFromJson(Map<String, dynamic> json) =>
-    _$_LxdEventLogging(
+_$_LxdEventLogging _$$_LxdEventLoggingFromJson(Map json) => _$_LxdEventLogging(
       message: json['message'] as String,
       level: json['level'] as String,
       context: Map<String, String>.from(json['context'] as Map),
@@ -43,15 +44,17 @@ Map<String, dynamic> _$$_LxdEventLoggingToJson(_$_LxdEventLogging instance) =>
       'context': instance.context,
     };
 
-_$_LxdEventLifecycle _$$_LxdEventLifecycleFromJson(Map<String, dynamic> json) =>
+_$_LxdEventLifecycle _$$_LxdEventLifecycleFromJson(Map json) =>
     _$_LxdEventLifecycle(
       action: json['action'] as String,
       source: json['source'] as String,
-      context: json['context'] as Map<String, dynamic>?,
+      context: (json['context'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, e),
+      ),
       requestor: json['requestor'] == null
           ? null
           : LxdEventLifecycleRequestor.fromJson(
-              json['requestor'] as Map<String, dynamic>),
+              Map<String, dynamic>.from(json['requestor'] as Map)),
     );
 
 Map<String, dynamic> _$$_LxdEventLifecycleToJson(
@@ -64,7 +67,7 @@ Map<String, dynamic> _$$_LxdEventLifecycleToJson(
     };
 
 _$_LxdEventLifecycleRequestor _$$_LxdEventLifecycleRequestorFromJson(
-        Map<String, dynamic> json) =>
+        Map json) =>
     _$_LxdEventLifecycleRequestor(
       username: json['username'] as String,
       protocol: json['protocol'] as String,

--- a/packages/lxd/lib/src/api/image.g.dart
+++ b/packages/lxd/lib/src/api/image.g.dart
@@ -6,10 +6,10 @@ part of 'image.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdImage _$$_LxdImageFromJson(Map<String, dynamic> json) => _$_LxdImage(
+_$_LxdImage _$$_LxdImageFromJson(Map json) => _$_LxdImage(
       autoUpdate: json['auto_update'] as bool? ?? false,
-      properties: (json['properties'] as Map<String, dynamic>?)?.map(
-            (k, e) => MapEntry(k, e as String),
+      properties: (json['properties'] as Map?)?.map(
+            (k, e) => MapEntry(k as String, e as String),
           ) ??
           const {},
       public: json['public'] as bool? ?? true,
@@ -19,7 +19,8 @@ _$_LxdImage _$$_LxdImageFromJson(Map<String, dynamic> json) => _$_LxdImage(
               .toList() ??
           const [],
       aliases: (json['aliases'] as List<dynamic>?)
-              ?.map((e) => LxdImageAlias.fromJson(e as Map<String, dynamic>))
+              ?.map((e) =>
+                  LxdImageAlias.fromJson(Map<String, dynamic>.from(e as Map)))
               .toList() ??
           const [],
       architecture: json['architecture'] as String,
@@ -30,7 +31,7 @@ _$_LxdImage _$$_LxdImageFromJson(Map<String, dynamic> json) => _$_LxdImage(
       updateSource: json['update_source'] == null
           ? null
           : LxdImageSource.fromJson(
-              json['update_source'] as Map<String, dynamic>),
+              Map<String, dynamic>.from(json['update_source'] as Map)),
       type: $enumDecode(_$LxdImageTypeEnumMap, json['type']),
       createdAt: DateTime.parse(json['created_at'] as String),
       lastUsedAt: json['last_used_at'] == null
@@ -64,8 +65,7 @@ const _$LxdImageTypeEnumMap = {
   LxdImageType.virtualMachine: 'virtual-machine',
 };
 
-_$_LxdImageAlias _$$_LxdImageAliasFromJson(Map<String, dynamic> json) =>
-    _$_LxdImageAlias(
+_$_LxdImageAlias _$$_LxdImageAliasFromJson(Map json) => _$_LxdImageAlias(
       name: json['name'] as String,
       description: json['description'] as String?,
     );
@@ -76,8 +76,7 @@ Map<String, dynamic> _$$_LxdImageAliasToJson(_$_LxdImageAlias instance) =>
       'description': instance.description,
     };
 
-_$_LxdImageSource _$$_LxdImageSourceFromJson(Map<String, dynamic> json) =>
-    _$_LxdImageSource(
+_$_LxdImageSource _$$_LxdImageSourceFromJson(Map json) => _$_LxdImageSource(
       alias: json['alias'] as String,
       certificate: json['certificate'] as String?,
       protocol: json['protocol'] as String,
@@ -95,15 +94,17 @@ Map<String, dynamic> _$$_LxdImageSourceToJson(_$_LxdImageSource instance) =>
       'image_type': _$LxdImageTypeEnumMap[instance.imageType],
     };
 
-_$_LxdImageMetadata _$$_LxdImageMetadataFromJson(Map<String, dynamic> json) =>
+_$_LxdImageMetadata _$$_LxdImageMetadataFromJson(Map json) =>
     _$_LxdImageMetadata(
       architecture: json['architecture'] as String,
       creationDate: json['creation_date'] as int,
       expiryDate: json['expiry_date'] as int,
       properties: Map<String, String>.from(json['properties'] as Map),
-      templates: (json['templates'] as Map<String, dynamic>).map(
+      templates: (json['templates'] as Map).map(
         (k, e) => MapEntry(
-            k, LxdImageMetadataTemplate.fromJson(e as Map<String, dynamic>)),
+            k as String,
+            LxdImageMetadataTemplate.fromJson(
+                Map<String, dynamic>.from(e as Map))),
       ),
     );
 
@@ -116,8 +117,7 @@ Map<String, dynamic> _$$_LxdImageMetadataToJson(_$_LxdImageMetadata instance) =>
       'templates': instance.templates.map((k, e) => MapEntry(k, e.toJson())),
     };
 
-_$_LxdImageMetadataTemplate _$$_LxdImageMetadataTemplateFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdImageMetadataTemplate _$$_LxdImageMetadataTemplateFromJson(Map json) =>
     _$_LxdImageMetadataTemplate(
       when: (json['when'] as List<dynamic>).map((e) => e as String).toList(),
       createOnly: json['create_only'] as bool,

--- a/packages/lxd/lib/src/api/instance.g.dart
+++ b/packages/lxd/lib/src/api/instance.g.dart
@@ -6,12 +6,11 @@ part of 'instance.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdInstance _$$_LxdInstanceFromJson(Map<String, dynamic> json) =>
-    _$_LxdInstance(
+_$_LxdInstance _$$_LxdInstanceFromJson(Map json) => _$_LxdInstance(
       architecture: json['architecture'] as String,
       config: Map<String, String>.from(json['config'] as Map),
-      devices: (json['devices'] as Map<String, dynamic>).map(
-        (k, e) => MapEntry(k, Map<String, String>.from(e as Map)),
+      devices: (json['devices'] as Map).map(
+        (k, e) => MapEntry(k as String, Map<String, String>.from(e as Map)),
       ),
       ephemeral: json['ephemeral'] as bool,
       profiles:
@@ -20,11 +19,11 @@ _$_LxdInstance _$$_LxdInstanceFromJson(Map<String, dynamic> json) =>
       stateful: json['stateful'] as bool,
       description: json['description'] as String,
       createdAt: DateTime.parse(json['created_at'] as String),
-      expandedConfig: (json['expanded_config'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, e as String),
+      expandedConfig: (json['expanded_config'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, e as String),
       ),
-      expandedDevices: (json['expanded_devices'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(k, Map<String, String>.from(e as Map)),
+      expandedDevices: (json['expanded_devices'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, Map<String, String>.from(e as Map)),
       ),
       name: json['name'] as String,
       status: json['status'] as String,

--- a/packages/lxd/lib/src/api/instance_state.g.dart
+++ b/packages/lxd/lib/src/api/instance_state.g.dart
@@ -6,27 +6,30 @@ part of 'instance_state.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdInstanceState _$$_LxdInstanceStateFromJson(Map<String, dynamic> json) =>
+_$_LxdInstanceState _$$_LxdInstanceStateFromJson(Map json) =>
     _$_LxdInstanceState(
       status: $enumDecode(_$LxdInstanceStatusEnumMap, json['status']),
       statusCode: json['status_code'] as int,
-      disk: (json['disk'] as Map<String, dynamic>?)?.map(
-        (k, e) => MapEntry(
-            k, LxdInstanceDiskState.fromJson(e as Map<String, dynamic>)),
+      disk: (json['disk'] as Map?)?.map(
+        (k, e) => MapEntry(k as String,
+            LxdInstanceDiskState.fromJson(Map<String, dynamic>.from(e as Map))),
       ),
       memory: json['memory'] == null
           ? null
           : LxdInstanceMemoryState.fromJson(
-              json['memory'] as Map<String, dynamic>),
-      network: (json['network'] as Map<String, dynamic>?)?.map(
+              Map<String, dynamic>.from(json['memory'] as Map)),
+      network: (json['network'] as Map?)?.map(
         (k, e) => MapEntry(
-            k, LxdInstanceNetworkState.fromJson(e as Map<String, dynamic>)),
+            k as String,
+            LxdInstanceNetworkState.fromJson(
+                Map<String, dynamic>.from(e as Map))),
       ),
       pid: json['pid'] as int,
       processes: json['processes'] as int? ?? -1,
       cpu: json['cpu'] == null
           ? null
-          : LxdInstanceCpuState.fromJson(json['cpu'] as Map<String, dynamic>),
+          : LxdInstanceCpuState.fromJson(
+              Map<String, dynamic>.from(json['cpu'] as Map)),
     );
 
 Map<String, dynamic> _$$_LxdInstanceStateToJson(_$_LxdInstanceState instance) =>
@@ -48,8 +51,7 @@ const _$LxdInstanceStatusEnumMap = {
   LxdInstanceStatus.error: 'Error',
 };
 
-_$_LxdInstanceDiskState _$$_LxdInstanceDiskStateFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdInstanceDiskState _$$_LxdInstanceDiskStateFromJson(Map json) =>
     _$_LxdInstanceDiskState(
       usage: json['usage'] as int,
     );
@@ -60,8 +62,7 @@ Map<String, dynamic> _$$_LxdInstanceDiskStateToJson(
       'usage': instance.usage,
     };
 
-_$_LxdInstanceCpuState _$$_LxdInstanceCpuStateFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdInstanceCpuState _$$_LxdInstanceCpuStateFromJson(Map json) =>
     _$_LxdInstanceCpuState(
       usage: json['usage'] as int,
     );
@@ -72,8 +73,7 @@ Map<String, dynamic> _$$_LxdInstanceCpuStateToJson(
       'usage': instance.usage,
     };
 
-_$_LxdInstanceMemoryState _$$_LxdInstanceMemoryStateFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdInstanceMemoryState _$$_LxdInstanceMemoryStateFromJson(Map json) =>
     _$_LxdInstanceMemoryState(
       usage: json['usage'] as int,
       usagePeak: json['usage_peak'] as int,
@@ -90,15 +90,14 @@ Map<String, dynamic> _$$_LxdInstanceMemoryStateToJson(
       'swap_usage_peak': instance.swapUsagePeak,
     };
 
-_$_LxdInstanceNetworkState _$$_LxdInstanceNetworkStateFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdInstanceNetworkState _$$_LxdInstanceNetworkStateFromJson(Map json) =>
     _$_LxdInstanceNetworkState(
       addresses: (json['addresses'] as List<dynamic>)
-          .map((e) =>
-              LxdInstanceNetworkAddress.fromJson(e as Map<String, dynamic>))
+          .map((e) => LxdInstanceNetworkAddress.fromJson(
+              Map<String, dynamic>.from(e as Map)))
           .toList(),
       counters: LxdInstanceNetworkCounters.fromJson(
-          json['counters'] as Map<String, dynamic>),
+          Map<String, dynamic>.from(json['counters'] as Map)),
       hwaddr: json['hwaddr'] as String,
       hostName: json['host_name'] as String,
       mtu: json['mtu'] as int,
@@ -118,8 +117,7 @@ Map<String, dynamic> _$$_LxdInstanceNetworkStateToJson(
       'type': instance.type,
     };
 
-_$_LxdInstanceNetworkAddress _$$_LxdInstanceNetworkAddressFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdInstanceNetworkAddress _$$_LxdInstanceNetworkAddressFromJson(Map json) =>
     _$_LxdInstanceNetworkAddress(
       family: $enumDecode(_$LxdNetworkFamilyEnumMap, json['family']),
       address: json['address'] as String,
@@ -148,7 +146,7 @@ const _$LxdNetworkScopeEnumMap = {
 };
 
 _$_LxdInstanceNetworkCounters _$$_LxdInstanceNetworkCountersFromJson(
-        Map<String, dynamic> json) =>
+        Map json) =>
     _$_LxdInstanceNetworkCounters(
       bytesReceived: json['bytes_received'] as int,
       bytesSent: json['bytes_sent'] as int,

--- a/packages/lxd/lib/src/api/network.g.dart
+++ b/packages/lxd/lib/src/api/network.g.dart
@@ -6,8 +6,7 @@ part of 'network.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdNetwork _$$_LxdNetworkFromJson(Map<String, dynamic> json) =>
-    _$_LxdNetwork(
+_$_LxdNetwork _$$_LxdNetworkFromJson(Map json) => _$_LxdNetwork(
       config: Map<String, String>.from(json['config'] as Map),
       description: json['description'] as String,
       managed: json['managed'] as bool,
@@ -26,8 +25,7 @@ Map<String, dynamic> _$$_LxdNetworkToJson(_$_LxdNetwork instance) =>
       'type': instance.type,
     };
 
-_$_LxdNetworkLease _$$_LxdNetworkLeaseFromJson(Map<String, dynamic> json) =>
-    _$_LxdNetworkLease(
+_$_LxdNetworkLease _$$_LxdNetworkLeaseFromJson(Map json) => _$_LxdNetworkLease(
       address: json['address'] as String,
       hostname: json['hostname'] as String,
       hwaddr: json['hwaddr'] as String,
@@ -44,13 +42,13 @@ Map<String, dynamic> _$$_LxdNetworkLeaseToJson(_$_LxdNetworkLease instance) =>
       'type': instance.type,
     };
 
-_$_LxdNetworkState _$$_LxdNetworkStateFromJson(Map<String, dynamic> json) =>
-    _$_LxdNetworkState(
+_$_LxdNetworkState _$$_LxdNetworkStateFromJson(Map json) => _$_LxdNetworkState(
       addresses: (json['addresses'] as List<dynamic>)
-          .map((e) => LxdNetworkAddress.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              LxdNetworkAddress.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
-      counters:
-          LxdNetworkCounters.fromJson(json['counters'] as Map<String, dynamic>),
+      counters: LxdNetworkCounters.fromJson(
+          Map<String, dynamic>.from(json['counters'] as Map)),
       hwaddr: json['hwaddr'] as String,
       mtu: json['mtu'] as int,
       state: json['state'] as String,
@@ -67,7 +65,7 @@ Map<String, dynamic> _$$_LxdNetworkStateToJson(_$_LxdNetworkState instance) =>
       'type': instance.type,
     };
 
-_$_LxdNetworkAddress _$$_LxdNetworkAddressFromJson(Map<String, dynamic> json) =>
+_$_LxdNetworkAddress _$$_LxdNetworkAddressFromJson(Map json) =>
     _$_LxdNetworkAddress(
       address: json['address'] as String,
       family: json['family'] as String,
@@ -84,8 +82,7 @@ Map<String, dynamic> _$$_LxdNetworkAddressToJson(
       'scope': instance.scope,
     };
 
-_$_LxdNetworkCounters _$$_LxdNetworkCountersFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdNetworkCounters _$$_LxdNetworkCountersFromJson(Map json) =>
     _$_LxdNetworkCounters(
       bytesReceived: json['bytes_received'] as int,
       bytesSent: json['bytes_sent'] as int,

--- a/packages/lxd/lib/src/api/network_acl.g.dart
+++ b/packages/lxd/lib/src/api/network_acl.g.dart
@@ -6,7 +6,7 @@ part of 'network_acl.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdNetworkAclRule _$$_LxdNetworkAclRuleFromJson(Map<String, dynamic> json) =>
+_$_LxdNetworkAclRule _$$_LxdNetworkAclRuleFromJson(Map json) =>
     _$_LxdNetworkAclRule(
       action: json['action'] as String,
       source: json['source'] as String?,
@@ -44,15 +44,16 @@ Map<String, dynamic> _$$_LxdNetworkAclRuleToJson(
   return val;
 }
 
-_$_LxdNetworkAcl _$$_LxdNetworkAclFromJson(Map<String, dynamic> json) =>
-    _$_LxdNetworkAcl(
+_$_LxdNetworkAcl _$$_LxdNetworkAclFromJson(Map json) => _$_LxdNetworkAcl(
       name: json['name'] as String,
       description: json['description'] as String,
       egress: (json['egress'] as List<dynamic>)
-          .map((e) => LxdNetworkAclRule.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              LxdNetworkAclRule.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
       ingress: (json['ingress'] as List<dynamic>)
-          .map((e) => LxdNetworkAclRule.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              LxdNetworkAclRule.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
       config: Map<String, String>.from(json['config'] as Map),
       usedBy:

--- a/packages/lxd/lib/src/api/operation.g.dart
+++ b/packages/lxd/lib/src/api/operation.g.dart
@@ -6,8 +6,7 @@ part of 'operation.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdOperation _$$_LxdOperationFromJson(Map<String, dynamic> json) =>
-    _$_LxdOperation(
+_$_LxdOperation _$$_LxdOperationFromJson(Map json) => _$_LxdOperation(
       id: json['id'] as String,
       type: $enumDecode(_$LxdOperationTypeEnumMap, json['class']),
       description: json['description'] as String,
@@ -15,11 +14,13 @@ _$_LxdOperation _$$_LxdOperationFromJson(Map<String, dynamic> json) =>
       updatedAt: DateTime.parse(json['updated_at'] as String),
       status: json['status'] as String,
       statusCode: json['status_code'] as int,
-      resources: (json['resources'] as Map<String, dynamic>?)?.map(
-        (k, e) =>
-            MapEntry(k, (e as List<dynamic>).map((e) => e as String).toList()),
+      resources: (json['resources'] as Map?)?.map(
+        (k, e) => MapEntry(
+            k as String, (e as List<dynamic>).map((e) => e as String).toList()),
       ),
-      metadata: json['metadata'] as Map<String, dynamic>?,
+      metadata: (json['metadata'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, e),
+      ),
       mayCancel: json['may_cancel'] as bool,
       error: json['err'] as String,
       location: json['location'] as String,

--- a/packages/lxd/lib/src/api/profile.g.dart
+++ b/packages/lxd/lib/src/api/profile.g.dart
@@ -6,8 +6,7 @@ part of 'profile.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdProfile _$$_LxdProfileFromJson(Map<String, dynamic> json) =>
-    _$_LxdProfile(
+_$_LxdProfile _$$_LxdProfileFromJson(Map json) => _$_LxdProfile(
       config: Map<String, String>.from(json['config'] as Map),
       description: json['description'] as String,
       name: json['name'] as String,

--- a/packages/lxd/lib/src/api/project.g.dart
+++ b/packages/lxd/lib/src/api/project.g.dart
@@ -6,8 +6,7 @@ part of 'project.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdProject _$$_LxdProjectFromJson(Map<String, dynamic> json) =>
-    _$_LxdProject(
+_$_LxdProject _$$_LxdProjectFromJson(Map json) => _$_LxdProject(
       config: Map<String, String>.from(json['config'] as Map),
       description: json['description'] as String,
       name: json['name'] as String,

--- a/packages/lxd/lib/src/api/project_state.g.dart
+++ b/packages/lxd/lib/src/api/project_state.g.dart
@@ -6,8 +6,7 @@ part of 'project_state.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdProjectStateResource _$$_LxdProjectStateResourceFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdProjectStateResource _$$_LxdProjectStateResourceFromJson(Map json) =>
     _$_LxdProjectStateResource(
       limit: json['Limit'] as int,
       usage: json['Usage'] as int,
@@ -20,11 +19,12 @@ Map<String, dynamic> _$$_LxdProjectStateResourceToJson(
       'Usage': instance.usage,
     };
 
-_$_LxdProjectState _$$_LxdProjectStateFromJson(Map<String, dynamic> json) =>
-    _$_LxdProjectState(
-      resources: (json['resources'] as Map<String, dynamic>).map(
+_$_LxdProjectState _$$_LxdProjectStateFromJson(Map json) => _$_LxdProjectState(
+      resources: (json['resources'] as Map).map(
         (k, e) => MapEntry(
-            k, LxdProjectStateResource.fromJson(e as Map<String, dynamic>)),
+            k as String,
+            LxdProjectStateResource.fromJson(
+                Map<String, dynamic>.from(e as Map))),
       ),
     );
 

--- a/packages/lxd/lib/src/api/resource.g.dart
+++ b/packages/lxd/lib/src/api/resource.g.dart
@@ -6,8 +6,7 @@ part of 'resource.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdCpuResources _$$_LxdCpuResourcesFromJson(Map<String, dynamic> json) =>
-    _$_LxdCpuResources(
+_$_LxdCpuResources _$$_LxdCpuResourcesFromJson(Map json) => _$_LxdCpuResources(
       architecture: json['architecture'] as String,
       sockets:
           (json['sockets'] as List<dynamic>).map((e) => e as String).toList(),
@@ -19,8 +18,7 @@ Map<String, dynamic> _$$_LxdCpuResourcesToJson(_$_LxdCpuResources instance) =>
       'sockets': instance.sockets,
     };
 
-_$_LxdMemoryResources _$$_LxdMemoryResourcesFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdMemoryResources _$$_LxdMemoryResourcesFromJson(Map json) =>
     _$_LxdMemoryResources(
       used: json['used'] as int,
       total: json['total'] as int,
@@ -33,10 +31,9 @@ Map<String, dynamic> _$$_LxdMemoryResourcesToJson(
       'total': instance.total,
     };
 
-_$_LxdGpuResources _$$_LxdGpuResourcesFromJson(Map<String, dynamic> json) =>
-    _$_LxdGpuResources(
+_$_LxdGpuResources _$$_LxdGpuResourcesFromJson(Map json) => _$_LxdGpuResources(
       cards: (json['cards'] as List<dynamic>)
-          .map((e) => LxdGpuCard.fromJson(e as Map<String, dynamic>))
+          .map((e) => LxdGpuCard.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
     );
 
@@ -45,8 +42,7 @@ Map<String, dynamic> _$$_LxdGpuResourcesToJson(_$_LxdGpuResources instance) =>
       'cards': instance.cards.map((e) => e.toJson()).toList(),
     };
 
-_$_LxdGpuCard _$$_LxdGpuCardFromJson(Map<String, dynamic> json) =>
-    _$_LxdGpuCard(
+_$_LxdGpuCard _$$_LxdGpuCardFromJson(Map json) => _$_LxdGpuCard(
       driver: json['driver'] as String,
       driverVersion: json['driver_version'] as String,
       vendor: json['vendor'] as String,
@@ -61,11 +57,11 @@ Map<String, dynamic> _$$_LxdGpuCardToJson(_$_LxdGpuCard instance) =>
       'vendor_id': instance.vendorId,
     };
 
-_$_LXdNetworkResources _$$_LXdNetworkResourcesFromJson(
-        Map<String, dynamic> json) =>
+_$_LXdNetworkResources _$$_LXdNetworkResourcesFromJson(Map json) =>
     _$_LXdNetworkResources(
       cards: (json['cards'] as List<dynamic>)
-          .map((e) => LxdNetworkCard.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              LxdNetworkCard.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
     );
 
@@ -75,8 +71,7 @@ Map<String, dynamic> _$$_LXdNetworkResourcesToJson(
       'cards': instance.cards.map((e) => e.toJson()).toList(),
     };
 
-_$_LxdNetworkCard _$$_LxdNetworkCardFromJson(Map<String, dynamic> json) =>
-    _$_LxdNetworkCard(
+_$_LxdNetworkCard _$$_LxdNetworkCardFromJson(Map json) => _$_LxdNetworkCard(
       driver: json['driver'] as String,
       driverVersion: json['driver_version'] as String,
       vendor: json['vendor'] as String,
@@ -91,11 +86,11 @@ Map<String, dynamic> _$$_LxdNetworkCardToJson(_$_LxdNetworkCard instance) =>
       'vendor_id': instance.vendorId,
     };
 
-_$_LxdStorageResources _$$_LxdStorageResourcesFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdStorageResources _$$_LxdStorageResourcesFromJson(Map json) =>
     _$_LxdStorageResources(
       disks: (json['disks'] as List<dynamic>)
-          .map((e) => LxdStorageDisk.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              LxdStorageDisk.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
     );
 
@@ -105,8 +100,7 @@ Map<String, dynamic> _$$_LxdStorageResourcesToJson(
       'disks': instance.disks.map((e) => e.toJson()).toList(),
     };
 
-_$_LxdStorageDisk _$$_LxdStorageDiskFromJson(Map<String, dynamic> json) =>
-    _$_LxdStorageDisk(
+_$_LxdStorageDisk _$$_LxdStorageDiskFromJson(Map json) => _$_LxdStorageDisk(
       id: json['id'] as String,
       model: json['model'] as String,
       serial: json['serial'] as String,
@@ -123,10 +117,10 @@ Map<String, dynamic> _$$_LxdStorageDiskToJson(_$_LxdStorageDisk instance) =>
       'type': instance.type,
     };
 
-_$_LxdUsbResources _$$_LxdUsbResourcesFromJson(Map<String, dynamic> json) =>
-    _$_LxdUsbResources(
+_$_LxdUsbResources _$$_LxdUsbResourcesFromJson(Map json) => _$_LxdUsbResources(
       devices: (json['devices'] as List<dynamic>)
-          .map((e) => LxdUsbDevice.fromJson(e as Map<String, dynamic>))
+          .map(
+              (e) => LxdUsbDevice.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
     );
 
@@ -135,8 +129,7 @@ Map<String, dynamic> _$$_LxdUsbResourcesToJson(_$_LxdUsbResources instance) =>
       'devices': instance.devices.map((e) => e.toJson()).toList(),
     };
 
-_$_LxdUsbDevice _$$_LxdUsbDeviceFromJson(Map<String, dynamic> json) =>
-    _$_LxdUsbDevice(
+_$_LxdUsbDevice _$$_LxdUsbDeviceFromJson(Map json) => _$_LxdUsbDevice(
       busAddress: json['bus_address'] as int,
       deviceAddress: json['device_address'] as int,
       product: json['product'] as String,
@@ -157,10 +150,10 @@ Map<String, dynamic> _$$_LxdUsbDeviceToJson(_$_LxdUsbDevice instance) =>
       'vendor_id': instance.vendorId,
     };
 
-_$_LxdPciResources _$$_LxdPciResourcesFromJson(Map<String, dynamic> json) =>
-    _$_LxdPciResources(
+_$_LxdPciResources _$$_LxdPciResourcesFromJson(Map json) => _$_LxdPciResources(
       devices: (json['devices'] as List<dynamic>)
-          .map((e) => LxdPciDevice.fromJson(e as Map<String, dynamic>))
+          .map(
+              (e) => LxdPciDevice.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
     );
 
@@ -169,8 +162,7 @@ Map<String, dynamic> _$$_LxdPciResourcesToJson(_$_LxdPciResources instance) =>
       'devices': instance.devices.map((e) => e.toJson()).toList(),
     };
 
-_$_LxdPciDevice _$$_LxdPciDeviceFromJson(Map<String, dynamic> json) =>
-    _$_LxdPciDevice(
+_$_LxdPciDevice _$$_LxdPciDeviceFromJson(Map json) => _$_LxdPciDevice(
       driver: json['driver'] as String,
       driverVersion: json['driver_version'] as String,
       pciAddress: json['pci_address'] as String,
@@ -191,8 +183,7 @@ Map<String, dynamic> _$$_LxdPciDeviceToJson(_$_LxdPciDevice instance) =>
       'vendor_id': instance.vendorId,
     };
 
-_$_LxdFirmware _$$_LxdFirmwareFromJson(Map<String, dynamic> json) =>
-    _$_LxdFirmware(
+_$_LxdFirmware _$$_LxdFirmwareFromJson(Map json) => _$_LxdFirmware(
       date: json['date'] as String,
       vendor: json['vendor'] as String,
       version: json['version'] as String,
@@ -205,8 +196,7 @@ Map<String, dynamic> _$$_LxdFirmwareToJson(_$_LxdFirmware instance) =>
       'version': instance.version,
     };
 
-_$_LxdChassis _$$_LxdChassisFromJson(Map<String, dynamic> json) =>
-    _$_LxdChassis(
+_$_LxdChassis _$$_LxdChassisFromJson(Map json) => _$_LxdChassis(
       serial: json['serial'] as String,
       type: json['type'] as String,
       vendor: json['vendor'] as String,
@@ -221,8 +211,7 @@ Map<String, dynamic> _$$_LxdChassisToJson(_$_LxdChassis instance) =>
       'version': instance.version,
     };
 
-_$_LxdMotherboard _$$_LxdMotherboardFromJson(Map<String, dynamic> json) =>
-    _$_LxdMotherboard(
+_$_LxdMotherboard _$$_LxdMotherboardFromJson(Map json) => _$_LxdMotherboard(
       product: json['product'] as String,
       serial: json['serial'] as String,
       vendor: json['vendor'] as String,
@@ -237,8 +226,7 @@ Map<String, dynamic> _$$_LxdMotherboardToJson(_$_LxdMotherboard instance) =>
       'version': instance.version,
     };
 
-_$_LxdSystemResources _$$_LxdSystemResourcesFromJson(
-        Map<String, dynamic> json) =>
+_$_LxdSystemResources _$$_LxdSystemResourcesFromJson(Map json) =>
     _$_LxdSystemResources(
       uuid: json['uuid'] as String,
       vendor: json['vendor'] as String,
@@ -248,10 +236,12 @@ _$_LxdSystemResources _$$_LxdSystemResourcesFromJson(
       sku: json['sku'] as String,
       serial: json['serial'] as String,
       type: json['type'] as String,
-      firmware: LxdFirmware.fromJson(json['firmware'] as Map<String, dynamic>),
-      chassis: LxdChassis.fromJson(json['chassis'] as Map<String, dynamic>),
-      motherboard:
-          LxdMotherboard.fromJson(json['motherboard'] as Map<String, dynamic>),
+      firmware: LxdFirmware.fromJson(
+          Map<String, dynamic>.from(json['firmware'] as Map)),
+      chassis: LxdChassis.fromJson(
+          Map<String, dynamic>.from(json['chassis'] as Map)),
+      motherboard: LxdMotherboard.fromJson(
+          Map<String, dynamic>.from(json['motherboard'] as Map)),
     );
 
 Map<String, dynamic> _$$_LxdSystemResourcesToJson(
@@ -270,20 +260,23 @@ Map<String, dynamic> _$$_LxdSystemResourcesToJson(
       'motherboard': instance.motherboard.toJson(),
     };
 
-_$_LxdResources _$$_LxdResourcesFromJson(Map<String, dynamic> json) =>
-    _$_LxdResources(
-      cpu: LxdCpuResources.fromJson(json['cpu'] as Map<String, dynamic>),
-      memory:
-          LxdMemoryResources.fromJson(json['memory'] as Map<String, dynamic>),
-      gpu: LxdGpuResources.fromJson(json['gpu'] as Map<String, dynamic>),
-      network:
-          LXdNetworkResources.fromJson(json['network'] as Map<String, dynamic>),
-      storage:
-          LxdStorageResources.fromJson(json['storage'] as Map<String, dynamic>),
-      usb: LxdUsbResources.fromJson(json['usb'] as Map<String, dynamic>),
-      pci: LxdPciResources.fromJson(json['pci'] as Map<String, dynamic>),
-      system:
-          LxdSystemResources.fromJson(json['system'] as Map<String, dynamic>),
+_$_LxdResources _$$_LxdResourcesFromJson(Map json) => _$_LxdResources(
+      cpu: LxdCpuResources.fromJson(
+          Map<String, dynamic>.from(json['cpu'] as Map)),
+      memory: LxdMemoryResources.fromJson(
+          Map<String, dynamic>.from(json['memory'] as Map)),
+      gpu: LxdGpuResources.fromJson(
+          Map<String, dynamic>.from(json['gpu'] as Map)),
+      network: LXdNetworkResources.fromJson(
+          Map<String, dynamic>.from(json['network'] as Map)),
+      storage: LxdStorageResources.fromJson(
+          Map<String, dynamic>.from(json['storage'] as Map)),
+      usb: LxdUsbResources.fromJson(
+          Map<String, dynamic>.from(json['usb'] as Map)),
+      pci: LxdPciResources.fromJson(
+          Map<String, dynamic>.from(json['pci'] as Map)),
+      system: LxdSystemResources.fromJson(
+          Map<String, dynamic>.from(json['system'] as Map)),
     );
 
 Map<String, dynamic> _$$_LxdResourcesToJson(_$_LxdResources instance) =>

--- a/packages/lxd/lib/src/api/storage_pool.g.dart
+++ b/packages/lxd/lib/src/api/storage_pool.g.dart
@@ -6,8 +6,7 @@ part of 'storage_pool.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LxdStoragePool _$$_LxdStoragePoolFromJson(Map<String, dynamic> json) =>
-    _$_LxdStoragePool(
+_$_LxdStoragePool _$$_LxdStoragePoolFromJson(Map json) => _$_LxdStoragePool(
       config: Map<String, String>.from(json['config'] as Map),
       description: json['description'] as String,
       name: json['name'] as String,

--- a/packages/lxd/lib/src/response.g.dart
+++ b/packages/lxd/lib/src/response.g.dart
@@ -6,8 +6,7 @@ part of 'response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$LxdSyncResponse _$$LxdSyncResponseFromJson(Map<String, dynamic> json) =>
-    _$LxdSyncResponse(
+_$LxdSyncResponse _$$LxdSyncResponseFromJson(Map json) => _$LxdSyncResponse(
       status: json['status'] as String,
       statusCode: json['status_code'] as int,
       metadata: json['metadata'],
@@ -22,12 +21,11 @@ Map<String, dynamic> _$$LxdSyncResponseToJson(_$LxdSyncResponse instance) =>
       'type': instance.$type,
     };
 
-_$LxdAsyncResponse _$$LxdAsyncResponseFromJson(Map<String, dynamic> json) =>
-    _$LxdAsyncResponse(
+_$LxdAsyncResponse _$$LxdAsyncResponseFromJson(Map json) => _$LxdAsyncResponse(
       status: json['status'] as String,
       statusCode: json['status_code'] as int,
       operation: json['operation'] as String,
-      metadata: json['metadata'] as Map<String, dynamic>,
+      metadata: Map<String, dynamic>.from(json['metadata'] as Map),
       $type: json['type'] as String?,
     );
 
@@ -40,11 +38,12 @@ Map<String, dynamic> _$$LxdAsyncResponseToJson(_$LxdAsyncResponse instance) =>
       'type': instance.$type,
     };
 
-_$LxdErrorResponse _$$LxdErrorResponseFromJson(Map<String, dynamic> json) =>
-    _$LxdErrorResponse(
+_$LxdErrorResponse _$$LxdErrorResponseFromJson(Map json) => _$LxdErrorResponse(
       error: json['error'] as String,
       errorCode: json['error_code'] as int,
-      metadata: json['metadata'] as Map<String, dynamic>?,
+      metadata: (json['metadata'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, e),
+      ),
       $type: json['type'] as String?,
     );
 


### PR DESCRIPTION
This helps to ensure that empty JSON maps, for which the type is deducted as `Map<dynamic, dynamic>`, can be converted to `Map<String, dynamic>`.

Required for the config field in LXD server info:
- #293

See also:
- https://github.com/google/json_serializable.dart/issues/351