### PR TITLE
LXD service init: catch and log errors

### DIFF
--- a/packages/lxd_service/lib/src/service.dart
+++ b/packages/lxd_service/lib/src/service.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:lxd/lxd.dart';
 
 import 'features.dart';
 import 'instances.dart';
+import 'log.dart';
 import 'projects.dart';
 import 'terminal.dart';
 import 'vm.dart';
@@ -16,4 +19,13 @@ class LxdService extends LxdClient
         LxdVmService,
         LxdWatchService {
   LxdService({super.socketPath, super.client});
+
+  @override
+  Future<void> init() async {
+    try {
+      await super.init();
+    } on SocketException catch (e) {
+      log.error('Failed to initialize LXD', e);
+    }
+  }
 }

--- a/test/instance_info_model_test.mocks.dart
+++ b/test/instance_info_model_test.mocks.dart
@@ -243,6 +243,15 @@ class MockLxdService extends _i1.Mock implements _i5.LxdService {
         returnValue: _i6.Stream<_i2.LxdInstanceId>.empty(),
       ) as _i6.Stream<_i2.LxdInstanceId>);
   @override
+  _i6.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
   _i6.Future<Map<String, List<String>>> getOperations() => (super.noSuchMethod(
         Invocation.method(
           #getOperations,
@@ -1047,15 +1056,6 @@ class MockLxdService extends _i1.Mock implements _i5.LxdService {
           ),
         )),
       ) as _i6.Future<_i2.LxdOperation>);
-  @override
-  _i6.Future<void> init() => (super.noSuchMethod(
-        Invocation.method(
-          #init,
-          [],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
   @override
   _i6.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(

--- a/test/terminal_manager_test.mocks.dart
+++ b/test/terminal_manager_test.mocks.dart
@@ -243,6 +243,15 @@ class MockLxdService extends _i1.Mock implements _i5.LxdService {
         returnValue: _i6.Stream<_i2.LxdInstanceId>.empty(),
       ) as _i6.Stream<_i2.LxdInstanceId>);
   @override
+  _i6.Future<void> init() => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
   _i6.Future<Map<String, List<String>>> getOperations() => (super.noSuchMethod(
         Invocation.method(
           #getOperations,
@@ -1047,15 +1056,6 @@ class MockLxdService extends _i1.Mock implements _i5.LxdService {
           ),
         )),
       ) as _i6.Future<_i2.LxdOperation>);
-  @override
-  _i6.Future<void> init() => (super.noSuchMethod(
-        Invocation.method(
-          #init,
-          [],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
   @override
   _i6.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
This allows the GUI to at least start up. Server info / installation instructions will follow separately.

Ref: #291