### PR TITLE
Add delay for tooltips

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -13,6 +13,10 @@ import 'tabs/tab_page.dart';
 class Workshops extends StatelessWidget {
   const Workshops({super.key});
 
+  static const tooltipTheme = TooltipThemeData(
+    waitDuration: Duration(milliseconds: 500),
+  );
+
   @override
   Widget build(BuildContext context) {
     return CommandStore(
@@ -23,15 +27,19 @@ class Workshops extends StatelessWidget {
           // set explicit dialog background colors to avoid theme change
           // rendering issues (https://github.com/ubuntu/yaru.dart/issues/222)
           theme: yaru.theme?.copyWith(
+            tooltipTheme: tooltipTheme,
             dialogTheme: yaru.theme?.dialogTheme
                 .copyWith(backgroundColor: YaruColors.porcelain),
           ),
           darkTheme: yaru.darkTheme?.copyWith(
+            tooltipTheme: tooltipTheme,
             dialogTheme: yaru.darkTheme?.dialogTheme
                 .copyWith(backgroundColor: YaruColors.coolGrey),
           ),
-          highContrastTheme: yaruHighContrastLight,
-          highContrastDarkTheme: yaruHighContrastDark,
+          highContrastTheme:
+              yaruHighContrastLight.copyWith(tooltipTheme: tooltipTheme),
+          highContrastDarkTheme:
+              yaruHighContrastDark.copyWith(tooltipTheme: tooltipTheme),
           themeMode: context.themeMode,
           localizationsDelegates: const [
             ...AppLocalizations.localizationsDelegates,

--- a/lib/config_editor/config_editor_dialog.dart
+++ b/lib/config_editor/config_editor_dialog.dart
@@ -114,9 +114,14 @@ class ConfigEditor extends StatelessWidget {
         children: [
           Row(
             children: [
-              Tooltip(
-                message: description,
-                child: Text(name),
+              TooltipTheme(
+                data: const TooltipThemeData(
+                  waitDuration: Duration(milliseconds: 200),
+                ),
+                child: Tooltip(
+                  message: description,
+                  child: Text(name),
+                ),
               ),
               if (currentValue != null) ...[
                 const SizedBox(width: 8),

--- a/lib/config_editor/config_editor_dialog.dart
+++ b/lib/config_editor/config_editor_dialog.dart
@@ -114,14 +114,9 @@ class ConfigEditor extends StatelessWidget {
         children: [
           Row(
             children: [
-              TooltipTheme(
-                data: const TooltipThemeData(
-                  waitDuration: Duration(milliseconds: 200),
-                ),
-                child: Tooltip(
-                  message: description,
-                  child: Text(name),
-                ),
+              Tooltip(
+                message: description,
+                child: Text(name),
               ),
               if (currentValue != null) ...[
                 const SizedBox(width: 8),


### PR DESCRIPTION
This adds a delay to the tooltips in the config editor
fixes #289 

I have some questions regarding this since it's not mentioned in the issue itself:
- In case Tooltip widgets would be used in the future in other pages, should this be moved up the widget tree?
- IconButton widgets have tooltips but they don't have a waitDuration parameter. Would this difference in delays be detrimental enough to UX to warrant not making this change?
