### PR TITLE
Remove malfunctioning command palette close shortcut

### DIFF
--- a/assets/shortcuts.json
+++ b/assets/shortcuts.json
@@ -1,6 +1,5 @@
 {
   "commandPalette.open": "<Control><Shift>K",
-  "commandPalette.close": "Escape",
   "tab.new": "<Control><Shift>T",
   "tab.close": "<Control><Shift>W",
   "tab.next": "<Control>Page_Down",

--- a/lib/command_palette/command_palette_actions.dart
+++ b/lib/command_palette/command_palette_actions.dart
@@ -20,9 +20,3 @@ class CommandPaletteOpenAction
   @override
   void invokeCommandPalette(CommandPalette palette) => palette.open();
 }
-
-class CommandPaletteCloseAction
-    extends _CommandPaletteAction<CommandPaletteCloseIntent> {
-  @override
-  void invokeCommandPalette(CommandPalette palette) => palette.close();
-}

--- a/lib/command_palette/command_palette_commands.dart
+++ b/lib/command_palette/command_palette_commands.dart
@@ -19,11 +19,6 @@ class CommandPaletteCommands extends StatelessWidget {
           label: l10n.openPaletteCommand,
           intent: CommandPaletteOpenIntent(),
         ),
-        Command(
-          id: 'commandPalette.close',
-          label: l10n.closePaletteCommand,
-          intent: CommandPaletteCloseIntent(),
-        ),
       ],
       child: child,
     );

--- a/lib/command_palette/command_palette_page.dart
+++ b/lib/command_palette/command_palette_page.dart
@@ -25,7 +25,6 @@ class CommandPalettePage extends StatelessWidget {
         child: Actions(
           actions: {
             CommandPaletteOpenIntent: CommandPaletteOpenAction(),
-            CommandPaletteCloseIntent: CommandPaletteCloseAction(),
           },
           child: CommandPalette(
             config: CommandPaletteConfig(
@@ -35,9 +34,8 @@ class CommandPalettePage extends StatelessWidget {
                   hintText: l10n.searchCommandHint,
                 ),
               ),
-              // remove default shortcuts in favor of the command store
+              // remove default shortcut in favor of the command store
               openKeySet: LogicalKeySet(const LogicalKeyboardKey(-1)),
-              closeKeySet: LogicalKeySet(const LogicalKeyboardKey(-1)),
             ),
             actions: CommandStore.commandsOf(context)
                 .where((c) => c.label != null)


### PR DESCRIPTION
First of all, the shortcut did not work as expected. Escape works for closing the command palette regardless of what we try to define in the page context because the command palette is opened as an overlay into a different context.

Secondly, defining Escape shortcut on this level is problematic because it eats Escape key presses sent to the terminal pane.

Fixes: #311